### PR TITLE
Export GeoRocketCli as maven plugin

### DIFF
--- a/georocket-cli/build.gradle
+++ b/georocket-cli/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'application'
+apply plugin: 'maven'
 
 mainClassName = 'io.georocket.GeoRocketCli'
 


### PR DESCRIPTION
Necessary to use GeoRocketCli as local maven project.