### PR TITLE
Inheritance & IndexerMeta + (Filename, ID and timestamp) & Content-Type

### DIFF
--- a/georocket-server-api/src/main/java/io/georocket/storage/IndexMeta.java
+++ b/georocket-server-api/src/main/java/io/georocket/storage/IndexMeta.java
@@ -1,5 +1,6 @@
 package io.georocket.storage;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -10,34 +11,70 @@ import java.util.List;
 public class IndexMeta {
   private final List<String> tags;
   private final String fallbackCRSString;
+  private final String importId;
+  private final String fromFile;
+  private final Date importTimeStamp;
   
   /**
    * Default constructor
+   * @param importId The import id - identify to which specific import this meta data belongs
+   * @param fromFile The name of the imported file
+   * @param importTimeStamp The timestamp for this import
    */
-  public IndexMeta() {
-    this(null, null);
+  public IndexMeta(String importId, String fromFile, Date importTimeStamp) {
+    this(importId, fromFile, importTimeStamp, null, null);
   }
   
   /**
    * Construct the parameters
+   * @param importId The import id - identify to which specific import this meta data belongs
+   * @param fromFile The name of the imported file
+   * @param importTimeStamp The timestamp for this import
    * @param tags the list of tags to attach to the chunk (may be null)
    */
-  public IndexMeta(List<String> tags) {
-    this(tags, null);
+  public IndexMeta(String importId, String fromFile, Date importTimeStamp, List<String> tags) {
+    this(importId, fromFile, importTimeStamp, tags, null);
   }
   
   /**
    * Construct the parameters
+   * @param importId The import id - identify to which specific import this meta data belongs
+   * @param fromFile The name of the imported file
+   * @param importTimeStamp The timestamp for this import
    * @param tags the list of tags to attach to the chunk (may be null)
    * @param fallbackCRSString a string representing the CRS that should be used
    * to index the chunk to import if it does not specify a CRS itself (may be
    * null if no CRS is available as fallback)
    */
-  public IndexMeta(List<String> tags, String fallbackCRSString) {
+  public IndexMeta(String importId, String fromFile, Date importTimeStamp, List<String> tags, String fallbackCRSString) {
+    this.importId = importId;
+    this.fromFile = fromFile;
+    this.importTimeStamp = importTimeStamp;
     this.tags = tags;
     this.fallbackCRSString = fallbackCRSString;
   }
-  
+
+  /**
+   * @return the id for the import where this meta data was created from
+   */
+  public String getImportId() {
+    return this.importId;
+  }
+
+  /**
+   * @return the file name of the file this meta data was created from
+   */
+  public String getFromFile() {
+    return this.fromFile;
+  }
+
+  /**
+   * @return the timestamp of the event the data was imported
+   */
+  public Date getImportTimeStamp() {
+    return this.importTimeStamp;
+  }
+
   /**
    * @return the list of tags to attach to the chunk (may be null)
    */

--- a/georocket-server/build.gradle
+++ b/georocket-server/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile 'org.mongodb:bson:3.2.1'
     compile 'org.mongodb:mongodb-driver:3.2.1'
     compile 'org.yaml:snakeyaml:1.16'
+    compile 'org.apache.tika:tika-core:1.13'
 
     testCompile 'com.github.tomakehurst:wiremock:1.57'
     testCompile "de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.2"

--- a/georocket-server/src/main/java/io/georocket/GeoRocket.java
+++ b/georocket-server/src/main/java/io/georocket/GeoRocket.java
@@ -225,7 +225,8 @@ public class GeoRocket extends AbstractVerticle {
   private void onPost(RoutingContext context) {
     HttpServerRequest request = context.request();
     request.pause();
-    
+
+    String contentType = request.getHeader("Content-Type");
     String layer = getStorePath(context);
     String tagsStr = request.getParam("tags");
     List<String> tags = tagsStr != null ? Splitter.on(',')
@@ -280,7 +281,8 @@ public class GeoRocket extends AbstractVerticle {
         JsonObject msg = new JsonObject()
             .put("action", "import")
             .put("filename", id)
-            .put("layer", layer);
+            .put("layer", layer)
+            .put("contentType", contentType);
         if (tags != null) {
           msg.put("tags", new JsonArray(tags));
         }

--- a/georocket-server/src/main/java/io/georocket/ImporterVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/ImporterVerticle.java
@@ -1,6 +1,12 @@
 package io.georocket;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,6 +34,7 @@ import io.vertx.rx.java.RxHelper;
 import io.vertx.rxjava.core.AbstractVerticle;
 import io.vertx.rxjava.core.buffer.Buffer;
 import io.vertx.rxjava.core.eventbus.Message;
+import io.vertx.rxjava.core.file.AsyncFile;
 import io.vertx.rxjava.core.file.FileSystem;
 import io.vertx.rxjava.core.streams.ReadStream;
 import rx.Observable;
@@ -42,7 +49,7 @@ public class ImporterVerticle extends AbstractVerticle {
   private static final int MAX_RETRIES = 5;
   private static final int RETRY_INTERVAL = 1000;
   
-  private Store store;
+  protected Store store;
   private String incoming;
   
   @Override
@@ -61,7 +68,7 @@ public class ImporterVerticle extends AbstractVerticle {
    * Receives a message
    * @param msg the message 
    */
-  private void onMessage(Message<JsonObject> msg) {
+  protected void onMessage(Message<JsonObject> msg) {
     String action = msg.body().getString("action");
     switch (action) {
     case "import":
@@ -79,26 +86,33 @@ public class ImporterVerticle extends AbstractVerticle {
    * Receives a name of a file to import
    * @param msg the event bus message containing the filename
    */
-  private void onImport(Message<JsonObject> msg) {
+  protected void onImport(Message<JsonObject> msg) {
     JsonObject body = msg.body();
-    String filename = incoming + "/" + body.getString("filename");
+    String filename = body.getString("filename");
+    String filePath = incoming + "/" + filename;
     String layer = body.getString("layer", "/");
-    
+    String contentType = body.getString("contentType");
+
     // get tags
     JsonArray tagsArr = body.getJsonArray("tags");
     List<String> tags = tagsArr != null ? tagsArr.stream().flatMap(o -> o != null ?
         Stream.of(o.toString()) : Stream.of()).collect(Collectors.toList()) : null;
     
-    log.info("Importing " + filename + " to layer " + layer);
+    log.info("Importing " + filePath + " to layer " + layer);
+
+    // make this import explicit
+    String importId = UUID.randomUUID().toString();
+    Date timeStamp = Calendar.getInstance().getTime();
     
     FileSystem fs = vertx.fileSystem();
     OpenOptions openOptions = new OpenOptions().setCreate(false).setWrite(false);
-    fs.openObservable(filename, openOptions)
-      .flatMap(f -> importXML(f, layer, tags).finallyDo(() -> {
+
+    fs.openObservable(filePath, openOptions)
+      .flatMap(f -> importFile(contentType, f, importId, filename, timeStamp, layer, tags).finallyDo(() -> {
         // delete file from 'incoming' folder
-        log.info("Deleting " + filename + " from incoming folder");
+        log.info("Deleting " + filePath + " from incoming folder");
         f.closeObservable()
-          .flatMap(v -> fs.deleteObservable(filename))
+          .flatMap(v -> fs.deleteObservable(filePath))
           .subscribe(v -> {}, err -> {
             log.error("Could not delete file from 'incoming' folder", err);
           });
@@ -107,15 +121,43 @@ public class ImporterVerticle extends AbstractVerticle {
         log.error("Failed to import chunk", err);
       });
   }
-  
+
   /**
-   * Imports an XML file from the given input stream into the store
+   * Import a file from the given input stream into the store
+   * @param contentType The file content type
    * @param f the XML file to read
+   * @param importId the id of this import event
+   * @param filename the filename of the readed stream
+   * @param importTimeStamp the timestamp of this import event
    * @param layer the layer where the file should be stored (may be null)
    * @param tags the list of tags to attach to the file (may be null)
    * @return an observable that will emit when the file has been imported
    */
-  private Observable<Void> importXML(ReadStream<Buffer> f, String layer, List<String> tags) {
+  protected Observable<Void> importFile(String contentType, ReadStream<Buffer> f, String importId, String filename,
+                                        Date importTimeStamp, String layer, List<String> tags) {
+    switch (contentType) {
+      case "text/xml":
+        return importXML(f, importId, filename, importTimeStamp, layer, tags);
+      default:
+        log.error(String.format("Received an unexpected Content-Type '%s' during import of file '%s'", contentType, filename));
+    }
+
+    // Will be empty by default.
+    return Observable.<Void>empty();
+  }
+
+  /**
+   * Imports an XML file from the given input stream into the store
+   * @param f the XML file to read
+   * @param importId the id of this import event
+   * @param filename the filename of the readed stream
+   * @param importTimeStamp the timestamp of this import event
+   * @param layer the layer where the file should be stored (may be null)
+   * @param tags the list of tags to attach to the file (may be null)
+   * @return an observable that will emit when the file has been imported
+   */
+  private Observable<Void> importXML(ReadStream<Buffer> f, String importId, String filename, Date importTimeStamp,
+                                     String layer, List<String> tags) {
     AsyncXMLParser xmlParser = new AsyncXMLParser();
     Window window = new Window();
     Splitter splitter = new FirstLevelSplitter(window);
@@ -138,10 +180,9 @@ public class ImporterVerticle extends AbstractVerticle {
           
           // count number of chunks being written
           processing.incrementAndGet();
-          
-          IndexMeta indexMeta = new IndexMeta(tags, crsIndexer.getCRS());
-          Observable<Void> o = addToStore(result.getChunk(), result.getMeta(),
-              layer, indexMeta);
+
+          IndexMeta indexMeta = new IndexMeta(importId, filename, importTimeStamp, tags, crsIndexer.getCRS());
+          Observable<Void> o = addToStore(result.getChunk(), result.getMeta(), layer, indexMeta);
           return o.doOnNext(v -> {
             // resume stream only after all chunks from the current
             // buffer have been stored
@@ -154,7 +195,7 @@ public class ImporterVerticle extends AbstractVerticle {
         .last() // "wait" for last event (i.e. end of file)
         .finallyDo(xmlParser::close);
   }
-  
+
   /**
    * Add a chunk to the store
    * @param chunk the chunk to add
@@ -180,8 +221,7 @@ public class ImporterVerticle extends AbstractVerticle {
    * @return an observable that will emit exactly one item when the
    * operation has finished
    */
-  private Observable<Void> addToStore(String chunk, ChunkMeta meta,
-      String layer, IndexMeta indexMeta) {
+  protected Observable<Void> addToStore(String chunk, ChunkMeta meta, String layer, IndexMeta indexMeta) {
     return Observable.<Void>create(subscriber -> {
       addToStoreNoRetry(chunk, meta, layer, indexMeta).subscribe(subscriber);
     }).retryWhen(RxUtils.makeRetry(MAX_RETRIES, RETRY_INTERVAL, log));

--- a/georocket-server/src/main/java/io/georocket/ImporterVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/ImporterVerticle.java
@@ -136,6 +136,7 @@ public class ImporterVerticle extends AbstractVerticle {
   protected Observable<Void> importFile(String contentType, ReadStream<Buffer> f, String importId, String filename,
                                         Date importTimeStamp, String layer, List<String> tags) {
     switch (contentType) {
+      case "application/xml":
       case "text/xml":
         return importXML(f, importId, filename, importTimeStamp, layer, tags);
       default:

--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -74,14 +74,14 @@ import rx.functions.Func1;
 public class IndexerVerticle extends AbstractVerticle {
   private static Logger log = LoggerFactory.getLogger(IndexerVerticle.class);
   
-  private static final int MAX_ADD_REQUESTS = 1000;
-  private static final long BUFFER_TIMESPAN = 5000;
-  private static final int MAX_INSERT_REQUESTS = 5;
-  private static final int MAX_RETRIES = 5;
-  private static final int RETRY_INTERVAL = 1000;
-  
-  private static final String INDEX_NAME = "georocket";
-  private static final String TYPE_NAME = "object";
+  protected static final int MAX_ADD_REQUESTS = 1000;
+  protected static final long BUFFER_TIMESPAN = 5000;
+  protected static final int MAX_INSERT_REQUESTS = 5;
+  protected static final int MAX_RETRIES = 5;
+  protected static final int RETRY_INTERVAL = 1000;
+
+  protected static final String INDEX_NAME = "georocket";
+  protected static final String TYPE_NAME = "object";
   
   /**
    * The Elasticsearch node
@@ -91,22 +91,22 @@ public class IndexerVerticle extends AbstractVerticle {
   /**
    * The Elasticsearch client
    */
-  private Client client;
+  protected Client client;
   
   /**
    * The GeoRocket store
    */
-  private Store store;
+  protected Store store;
   
   /**
    * A list of {@link XMLIndexerFactory} objects
    */
-  private ImmutableList<XMLIndexerFactory> xmlIndexerFactories;
+  protected ImmutableList<XMLIndexerFactory> xmlIndexerFactories;
   
   /**
    * Compiles search strings to Elasticsearch documents
    */
-  private DefaultQueryCompiler queryCompiler;
+  protected DefaultQueryCompiler queryCompiler;
   
   /**
    * True if {@link #ensureIndex()} has been called at least once
@@ -152,9 +152,7 @@ public class IndexerVerticle extends AbstractVerticle {
       queryCompiler = new DefaultQueryCompiler(xmlIndexerFactories);
       store = StoreFactory.createStore((Vertx)vertx.getDelegate());
       
-      registerAdd();
-      registerDelete();
-      registerQuery();
+      registerMessageConsumers();
       
       startFuture.complete();
     });
@@ -164,6 +162,15 @@ public class IndexerVerticle extends AbstractVerticle {
   public void stop() {
     client.close();
     node.close();
+  }
+
+  /**
+   * Register all message consumers for this verticle.
+   */
+  protected void registerMessageConsumers() {
+    registerAdd();
+    registerDelete();
+    registerQuery();
   }
   
   /**
@@ -177,7 +184,7 @@ public class IndexerVerticle extends AbstractVerticle {
   /**
    * Register consumer for add messages
    */
-  private void registerAdd() {
+  protected void registerAdd() {
     vertx.eventBus().<JsonObject>consumer(AddressConstants.INDEXER_ADD)
       .toObservable()
       .buffer(BUFFER_TIMESPAN, TimeUnit.MILLISECONDS, MAX_ADD_REQUESTS)
@@ -222,7 +229,7 @@ public class IndexerVerticle extends AbstractVerticle {
   /**
    * Register consumer for delete messages
    */
-  private void registerDelete() {
+  protected void registerDelete() {
     vertx.eventBus().<JsonObject>consumer(AddressConstants.INDEXER_DELETE)
       .toObservable()
       .subscribe(msg -> {
@@ -238,7 +245,7 @@ public class IndexerVerticle extends AbstractVerticle {
   /**
    * Register consumer for queries
    */
-  private void registerQuery() {
+  protected void registerQuery() {
     vertx.eventBus().<JsonObject>consumer(AddressConstants.INDEXER_QUERY)
       .toObservable()
       .subscribe(msg -> {

--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -285,6 +285,11 @@ public class IndexerVerticle extends AbstractVerticle {
         String fallbackCRSString = body.getString("fallbackCRSString");
         
         log.trace("Indexing " + path);
+
+        String importId = body.getString("importId");
+        String filename = body.getString("filename");
+        Long importTime = body.getLong("importTime");
+
         
         // open chunk and create IndexRequest
         return openChunkToDocument(path, fallbackCRSString)
@@ -294,6 +299,10 @@ public class IndexerVerticle extends AbstractVerticle {
               if (tags != null) {
                 doc.put("tags", tags);
               }
+
+              doc.put("importId", importId);
+              doc.put("filename", filename);
+              doc.put("importTime", importTime);
             })
             .map(doc -> Pair.of(documentToIndexRequest(path, doc), msg))
             .onErrorResumeNext(err -> {

--- a/georocket-server/src/main/java/io/georocket/storage/indexed/IndexedStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/indexed/IndexedStore.java
@@ -44,6 +44,11 @@ public abstract class IndexedStore implements Store {
         JsonObject indexMsg = new JsonObject()
             .put("path", ar.result())
             .put("meta", chunkMeta.toJsonObject());
+
+        indexMsg.put("importId", indexMeta.getImportId());
+        indexMsg.put("filename", indexMeta.getFromFile());
+        indexMsg.put("importTime", indexMeta.getImportTimeStamp().getTime());
+
         if (indexMeta != null && indexMeta.getTags() != null) {
           indexMsg.put("tags", new JsonArray(indexMeta.getTags()));
         }

--- a/georocket-server/src/main/java/io/georocket/util/TikaFileTypeDetector.java
+++ b/georocket-server/src/main/java/io/georocket/util/TikaFileTypeDetector.java
@@ -1,0 +1,26 @@
+package io.georocket.util;
+
+import org.apache.tika.Tika;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.spi.FileTypeDetector;
+
+/**
+ * <p>File type detector that use the apache tika detector.</p>
+ *
+ * <p>This type detector use the magic number and file extension to guess the right content type.</p>
+ *
+ * <p>See {@link Tika#detect(Path)}</p>
+ *
+ * @author Andrej Sajenko
+ */
+public class TikaFileTypeDetector extends FileTypeDetector {
+
+  private Tika tika = new Tika();
+
+  @Override
+  public String probeContentType(Path path) throws IOException {
+    return tika.detect(path);
+  }
+}

--- a/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
+++ b/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
@@ -41,14 +41,31 @@ public class GeoRocketTest {
    */
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
-  
+
   /**
    * Tests if a small CityGML file can be uploaded correctly
    * @param context the test context
    * @throws Exception if an exception occurs
    */
   @Test
-  public void testMiniFile(TestContext context) throws Exception {
+  public void testMiniFileWithContentType(TestContext context) throws Exception {
+    this.testMiniFile(context, "application/xml");
+  }
+
+  /**
+   * <p>Tests if a small CityGML file can be uploaded correctly</p>
+   *
+   * <p>Test the content type guessing fallback</p>
+   *
+   * @param context the test context
+   * @throws Exception if an exception occurs
+   */
+  @Test
+  public void testMiniFileWithoutContentType(TestContext context) throws Exception {
+    this.testMiniFile(context, null);
+  }
+
+  private void testMiniFile(TestContext context, String contentType) throws Exception {
     String testFile = "berlin_alexanderplatz_mini.xml";
     
     Vertx vertx = rule.vertx();
@@ -83,6 +100,9 @@ public class GeoRocketTest {
             });
           });
           request.putHeader("Content-Length", String.valueOf(props.size()));
+          if (contentType != null) {
+            request.putHeader("Content-Type", contentType);
+          }
           Pump.pump(f, request).start();
           f.endHandler(v -> request.end());
         }));

--- a/georocket-server/src/test/java/io/georocket/storage/StorageTest.java
+++ b/georocket-server/src/test/java/io/georocket/storage/StorageTest.java
@@ -1,6 +1,8 @@
 package io.georocket.storage;
 
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import org.bson.types.ObjectId;
@@ -79,6 +81,16 @@ abstract public class StorageTest {
    * Test data: fallback CRS for chunk indexing
    */
   protected final static String FALLBACK_CRS_STRING = "EPSG:25832";
+
+  /**
+   * Test data: the import id of a file import
+   */
+  protected final static String IMPORT_ID = "Af023dasd3";
+
+  /**
+   * Test data: the timestamp for an import
+   */
+  protected final static Date TIME_STAMP = Calendar.getInstance().getTime();
 
   /**
    * Test data: a sample tag list for an Store::add method
@@ -427,7 +439,7 @@ abstract public class StorageTest {
       context.fail("Indexer should not be notified for a query event after"
           + "Store::add was called!"));
 
-    IndexMeta indexMeta = new IndexMeta(TAGS, FALLBACK_CRS_STRING);
+    IndexMeta indexMeta = new IndexMeta(IMPORT_ID, ID, TIME_STAMP, TAGS, FALLBACK_CRS_STRING);
     store.add(CHUNK_CONTENT, META, path, indexMeta, context.asyncAssertSuccess(err -> {
       validateAfterStoreAdd(context, vertx, path, context.asyncAssertSuccess(v -> {
         asyncAdd.complete();


### PR DESCRIPTION
* open GeoRocket verticles for inheritance
* add filename, id and timestamp as IndexMeta data
* read the content type on post and use it to make a decision between the import format
* * add a fallback for the content type if the client forget to send one, the type will be guessed by the file magic number and the file content
* extract start / stop methods from the indexer indexing and deleting methods