### PR TITLE
ContentType relations

### DIFF
--- a/georocket-server/src/main/java/io/georocket/ImporterVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/ImporterVerticle.java
@@ -18,6 +18,7 @@ import io.georocket.storage.IndexMeta;
 import io.georocket.storage.Store;
 import io.georocket.storage.StoreFactory;
 import io.georocket.util.AsyncXMLParser;
+import io.georocket.util.ContentType;
 import io.georocket.util.RxUtils;
 import io.georocket.util.Window;
 import io.vertx.core.file.OpenOptions;
@@ -172,14 +173,19 @@ public class ImporterVerticle extends AbstractVerticle {
   protected Observable<Integer> importFile(String contentType, ReadStream<Buffer> f,
       String importId, String filename, Date importTimeStamp, String layer,
       List<String> tags) {
-    switch (contentType) {
-      case "application/xml":
-      case "text/xml":
+
+    try {
+      ContentType type = ContentType.parse(contentType);
+
+      if (type.belongsToContentType("application/xml", "text/xml")) {
         return importXML(f, importId, filename, importTimeStamp, layer, tags);
-      default:
+      } else {
         return Observable.error(new NoStackTraceThrowable(String.format(
-            "Received an unexpected content type '%s' while trying to import"
-            + "file '%s'", contentType, filename)));
+                "Received an unexpected content type '%s' while trying to import"
+                        + "file '%s'", contentType, filename)));
+      }
+    } catch (IllegalArgumentException ex) {
+      return Observable.error(ex);
     }
   }
 

--- a/georocket-server/src/main/java/io/georocket/util/ContentType.java
+++ b/georocket-server/src/main/java/io/georocket/util/ContentType.java
@@ -1,0 +1,193 @@
+package io.georocket.util;
+
+import org.apache.commons.lang.StringUtils;
+import rx.Observable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A ContentType class to parse, compare content types and extract specific informations.
+ * @author Andrej Sajenko
+ */
+public class ContentType {
+
+  // type/specificType+subtype ; param ; param ; ...
+  private String type;
+  private String subtype;
+  private String specificType;
+  private Map<String, String> parameters;
+
+  /**
+   * <p>Example: application/gml+xml;version=1.0</p>
+   * <p>Groups: 1/2/3/4</p>
+   * <p>All Groups are always present but the values may be null!</p>
+   */
+  private static final Pattern pattern = Pattern.compile("(\\w*)\\/(\\w*\\+)?(\\w*)(.*)");
+
+  private ContentType(String type, String subtype, String specificType, Map<String, String> parameters) {
+    this.type = type;
+    this.subtype = subtype;
+    this.specificType = specificType;
+    this.parameters = parameters;
+  }
+
+  /**
+   * Parse a content type from a plain text string.
+   *
+   * <p>application/xml to type: application, subtype: xml</p>
+   * <p>application/gml+xml to type: application, subtype: xml, specificType: gml</p>
+   * <p>
+   * application/xml;charset=UTF-8; version="1.0" to type: application, subtype: xml,
+   * parameters: charset - UTF-8, version - 1.0
+   * </p>
+   *
+   * @param text The content type to parse.
+   *
+   * @return The parsed content type.
+   *
+   * @throws IllegalArgumentException If the text was not a content type.
+   */
+  public static ContentType parse(String text) {
+    Matcher matcher = pattern.matcher(text);
+    if (matcher.matches()) {
+      String type = matcher.group(1);
+
+      String specific = "";
+      if (matcher.groupCount() == 4) {
+        specific = matcher.group(2);
+        if (specific == null) {
+          specific = "";
+        } else {
+          specific = StringUtils.strip(specific, "+");
+        }
+      }
+
+      String subtype = matcher.group(3);
+      String unparsedParams = matcher.group(4);
+      Map<String, String> params = parseParams(unparsedParams);
+
+      return new ContentType(type, subtype, specific, params);
+    } else {
+      throw new IllegalArgumentException("Invalid contentType input");
+    }
+  }
+
+  private static Map<String, String> parseParams(String text) {
+    Map<String, String> result = new HashMap<>();
+    if (!text.trim().isEmpty()) {
+      Observable.from(text.split(";"))
+              .map(String::trim)
+              .filter(e -> !e.isEmpty())
+              .map(e -> e.split("="))
+              .filter(e -> e.length > 0)
+              .subscribe(e -> {
+                String key = e[0];
+                String value = "";
+                if (e.length == 2) {
+                  value = StringUtils.strip(e[1], "\"");
+                }
+                result.put(key, value);
+              });
+    }
+    return result;
+  }
+
+  /**
+   * @return The type <b>application</b> from the content type <i>application/xml</i>
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * @return The subtype <b>xml</b> from the conten type <i>application/xml</i>
+   */
+  public String getSubtype() {
+    return subtype;
+  }
+
+  /**
+   * @return The specific type <b>gml</b> from the conten type <i>application/gml+xml</i>
+   */
+  public String getSpecificType() {
+    return specificType;
+  }
+
+  /**
+   * @return The parameters <b>charset: utf-8 and version: 1.0</b> from the
+   * cointen type <i>application/xml; charset=utf-8;version="1.0"</i>
+   */
+  public Map<String, String> getParameters() {
+    return new HashMap<>(parameters);
+  }
+
+  /**
+   * Check: of any given content types contains this one.
+   *
+   * <p>
+   *   See: ContentType{@link #belongsToContentType(ContentType)}
+   * </p>
+   *
+   * @param contentTypes A collection of content types.
+   *
+   * @return True if this content type belongs to one of the contentTypes
+   */
+  public boolean belongsToContentType(String ... contentTypes) {
+    for (String type: contentTypes) {
+      if (this.belongsToContentType(type)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * <p>
+   *   Check: does a content type belongs to another one.
+   * </p>
+   *
+   * Examples:
+   * <p>application/xml <b>belongsTo</b> application/xml</p>
+   * <p>application/gml+xml <b>belongsTo</b> application/xml</p>
+   * <p>text/xml <b>belongs not to</b> application/xml</p>
+   *
+   * @param contentType The content type which may contains this one.
+   *
+   * @return true if belongs to the given content type.
+   */
+  public boolean belongsToContentType(ContentType contentType) {
+    if (!this.getType().equals(contentType.getType())) {
+      return false;
+    }
+    if (!this.getSubtype().equals(contentType.getSubtype())) {
+      return false;
+    }
+    if (!contentType.specificType.isEmpty()) {
+      return this.specificType.equals(contentType.specificType);
+    }
+    return true;
+  }
+
+  /**
+   * <p>
+   *   Check: does a content type belongs to another one.
+   * </p>
+   *
+   * Examples:
+   * <p>application/xml <b>belongsTo</b> application/xml</p>
+   * <p>application/gml+xml <b>belongsTo</b> application/xml</p>
+   * <p>text/xml <b>belongs not to</b> application/xml</p>
+   *
+   * @param contentType The content type which may contains this one.
+   *
+   * @return true if belongs to the given content type.
+   *
+   * @throws IllegalArgumentException If the text was not a content type.
+   */
+  public boolean belongsToContentType(String contentType) {
+    return this.belongsToContentType(ContentType.parse(contentType));
+  }
+}

--- a/georocket-server/src/test/java/io/georocket/util/ContentTypeTest.java
+++ b/georocket-server/src/test/java/io/georocket/util/ContentTypeTest.java
@@ -1,0 +1,103 @@
+package io.georocket.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for the ContentType class.
+ *
+ * @author Andrej Sajenko
+ */
+public class ContentTypeTest {
+
+  @Test
+  public void testParseSimpleType() {
+    String type = "application/xml";
+
+    ContentType cb = ContentType.parse(type);
+
+    assertEquals("application", cb.getType());
+    assertEquals("xml", cb.getSubtype());
+    assertEquals("", cb.getSpecificType());
+    assertEquals(0, cb.getParameters().size());
+  }
+
+  @Test
+  public void testParseSpecificType() {
+    String type = "application/gml+xml";
+
+    ContentType cb = ContentType.parse(type);
+
+    assertEquals("application", cb.getType());
+    assertEquals("xml", cb.getSubtype());
+    assertEquals("gml", cb.getSpecificType());
+    assertEquals(0, cb.getParameters().size());
+  }
+
+  @Test
+  public void testParseSimpleTypeWithParams1() {
+    String type = "application/xml; charset=utf-8";
+
+    ContentType cb = ContentType.parse(type);
+
+    assertEquals("application", cb.getType());
+    assertEquals("xml", cb.getSubtype());
+    assertEquals("", cb.getSpecificType());
+    assertEquals(1, cb.getParameters().size());
+    assertEquals("utf-8", cb.getParameters().get("charset"));
+  }
+
+  @Test
+  public void testParseSimpleTypeWithParams2() {
+    String type = "application/xml; charset=utf-8;version=\"1.0\"";
+
+    ContentType cb = ContentType.parse(type);
+
+    assertEquals("application", cb.getType());
+    assertEquals("xml", cb.getSubtype());
+    assertEquals("", cb.getSpecificType());
+    assertEquals(2, cb.getParameters().size());
+    assertEquals("utf-8", cb.getParameters().get("charset"));
+    assertEquals("1.0", cb.getParameters().get("version"));
+  }
+
+  @Test
+  public void testParseSpecificTypeWithParams() {
+    String type = "application/gml+xml; charset=utf-8;version=\"1.0\"";
+
+    ContentType cb = ContentType.parse(type);
+
+    assertEquals("application", cb.getType());
+    assertEquals("xml", cb.getSubtype());
+    assertEquals("gml", cb.getSpecificType());
+    assertEquals(2, cb.getParameters().size());
+    assertEquals("utf-8", cb.getParameters().get("charset"));
+    assertEquals("1.0", cb.getParameters().get("version"));
+  }
+
+  @Test
+  public void testBelongsToContentType() {
+    ContentType type = ContentType.parse("application/xml");
+
+    assertTrue(type.belongsToContentType("application/xml"));
+    assertFalse(type.belongsToContentType("application/json"));
+  }
+
+  @Test
+  public void testBelongsToContentTypeSpecific() {
+    ContentType type = ContentType.parse("application/gml+xml");
+
+    assertTrue(type.belongsToContentType("application/gml+xml"));
+    assertTrue(type.belongsToContentType("application/xml"));
+  }
+
+  @Test
+  public void testBelongsToContentTypeNot() {
+    ContentType type = ContentType.parse("application/xml");
+
+    assertFalse(type.belongsToContentType("application/gml+xml"));
+  }
+}


### PR DESCRIPTION
Hey, i created a ContentType class which parse a plain content type "text/xml".
With it we can extract the parts type/specific+subtype;params from the content type
and check if the content type has a relation to another one.

application/gml+xml belongs to application/xml

So we can support application/xml and every specific xml format like
* application/gml+xml
* application/example+xml
will be supported as well.