### PR TITLE
ignore project files for intellij

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 node_modules/
 src-gen/
 gradle.properties
+# IntelliJ  project structure
 .idea/
 *.iml
-
+/conf
+/elasticsearch
+/storage


### PR DESCRIPTION
IntelliJ use georocket as the project root not the gradle subprojects.
I have to ignore the files at the root folder.