### PR TITLE
Client prints status message not body part

### DIFF
--- a/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
+++ b/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
@@ -340,7 +340,8 @@ public class StoreEndpoint implements Endpoint {
       }, err -> {
         request.response()
           .setStatusCode(throwableToCode(err))
-          .end("Could not import file: " + err.getMessage());
+          .setStatusMessage("Could not import file: " + err.getMessage())
+          .end();
         err.printStackTrace();
         fs.delete(filepath, ar -> {});
       });


### PR DESCRIPTION
The client prints status code and status message (StoreClient#startImport(String layer, Collection<String> tags, Optional<Long> size, Handler<AsyncResult<Void>> handler)), Line 218.

Therefore, the server should not write the err message into the response`s body part.