### PR TITLE
Use correct path for mounting point

### DIFF
--- a/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
+++ b/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
@@ -87,7 +87,7 @@ public class StoreEndpoint implements Endpoint {
    */
   private String getStorePath(RoutingContext context) {
     String path = context.normalisedPath();
-    String routePath = context.currentRoute().getPath();
+    String routePath =  context.mountPoint();
     String result = null;
     if (routePath.length() < path.length()) {
       result = path.substring(routePath.length());


### PR DESCRIPTION
Change method to receive correct mount point.

If StoreEndpoint is mounted at "/store",

context.currentRoute().getPath() returns "/"
because that is the path of our createRouter() method

context.mountPoint() returns "/store/"
and that is exactly what we want.