### PR TITLE
store summary

### DIFF
--- a/georocket-server-api/src/main/java/io/georocket/storage/Store.java
+++ b/georocket-server-api/src/main/java/io/georocket/storage/Store.java
@@ -2,6 +2,7 @@ package io.georocket.storage;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 
 /**
  * A store for chunks
@@ -50,4 +51,10 @@ public interface Store {
    * @param handler will be called when the data size has been calculated
    */
   void getSize(Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Get the store's current meta information's.
+   * @param handler will be called when the data has been calculated
+   */
+  void getStoreSummery(Handler<AsyncResult<JsonObject>> handler);
 }

--- a/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
+++ b/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
@@ -74,7 +74,7 @@ public class StoreEndpoint implements Endpoint {
   @Override
   public Router createRouter() {
     Router router = Router.router(vertx);
-    router.head("/").handler(this::onHead);
+    router.get("/layers").handler(this::onHead);
     router.get("/*").handler(this::onGet);
     router.post("/*").handler(this::onPost);
     router.delete("/*").handler(this::onDelete);

--- a/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
+++ b/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
@@ -74,12 +74,29 @@ public class StoreEndpoint implements Endpoint {
   @Override
   public Router createRouter() {
     Router router = Router.router(vertx);
+    router.head("/").handler(this::onHead);
     router.get("/*").handler(this::onGet);
     router.post("/*").handler(this::onPost);
     router.delete("/*").handler(this::onDelete);
     return router;
   }
-  
+
+  /**
+   * Handle HEAD requests to get all meta information of the store.
+   * @param context the routing context
+   */
+  private void onHead(RoutingContext context) {
+    HttpServerResponse response = context.response();
+
+    store.getStoreSummeryObservable()
+      .subscribe(summary -> {
+        response.setStatusCode(200).end(summary.toString());
+      }, err -> {
+        log.error("Handle HEAD request failed", err);
+        response.setStatusCode(throwableToCode(err)).end(throwableToMessage(err, ""));
+      });
+  }
+
   /**
    * Get absolute data store path from request
    * @param context the current routing context

--- a/georocket-server/src/main/java/io/georocket/storage/RxStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/RxStore.java
@@ -126,7 +126,7 @@ public class RxStore implements Store {
   }
 
   /**
-   * Observable version of {@ling #getStoreSummery(Handler)}
+   * Observable version of {@link #getStoreSummery(Handler)}
    * @return on observable that emits the store summery.
    */
   public Observable<JsonObject> getStoreSummeryObservable() {

--- a/georocket-server/src/main/java/io/georocket/storage/RxStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/RxStore.java
@@ -2,9 +2,13 @@ package io.georocket.storage;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
 import io.vertx.rx.java.ObservableFuture;
 import io.vertx.rx.java.RxHelper;
+import javafx.collections.ObservableMap;
 import rx.Observable;
+
+import java.util.Map;
 
 /**
  * Wraps around {@link Store} and adds methods to be used with RxJava
@@ -105,7 +109,7 @@ public class RxStore implements Store {
   public void getSize(Handler<AsyncResult<Long>> handler) {
     delegate.getSize(handler);
   }
-  
+
   /**
    * Observable version of {@link #getSize(Handler)}
    * @return an observable that will emit the store's current size in bytes
@@ -113,6 +117,21 @@ public class RxStore implements Store {
   public Observable<Long> getSizeObservable() {
     ObservableFuture<Long> o = RxHelper.observableFuture();
     getSize(o.toHandler());
+    return o;
+  }
+
+  @Override
+  public void getStoreSummery(Handler<AsyncResult<JsonObject>> handler) {
+    delegate.getStoreSummery(handler);
+  }
+
+  /**
+   * Observable version of {@ling #getStoreSummery(Handler)}
+   * @return on observable that emits the store summery.
+   */
+  public Observable<JsonObject> getStoreSummeryObservable() {
+    ObservableFuture<JsonObject> o = RxHelper.observableFuture();
+    getStoreSummery(o.toHandler());
     return o;
   }
 }

--- a/georocket-server/src/main/java/io/georocket/storage/file/FileStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/file/FileStore.java
@@ -20,6 +20,7 @@ import io.vertx.core.file.FileProps;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.FileSystemProps;
 import io.vertx.core.file.OpenOptions;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.rx.java.ObservableFuture;
@@ -150,6 +151,12 @@ public class FileStore extends IndexedStore {
         handler.handle(Future.succeededFuture(size));
       }
     });
+  }
+
+  @Override
+  public void getStoreSummery(Handler<AsyncResult<JsonObject>> handler) {
+    handler.handle(Future.succeededFuture(new JsonObject()));
+    // TODO: start here
   }
 
   @Override

--- a/georocket-server/src/main/java/io/georocket/storage/hdfs/HDFSStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/hdfs/HDFSStore.java
@@ -116,6 +116,12 @@ public class HDFSStore extends IndexedStore {
     }, handler);
   }
 
+  @Override
+  public void getStoreSummery(Handler<AsyncResult<JsonObject>> handler) {
+    handler.handle(Future.succeededFuture(new JsonObject()));
+    // TODO: start here
+  }
+
   /**
    * Create a new file on HDFS
    * @param filename the file name

--- a/georocket-server/src/main/java/io/georocket/storage/hdfs/HDFSStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/hdfs/HDFSStore.java
@@ -4,8 +4,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Date;
 import java.util.Queue;
 
+import io.georocket.util.StoreSummaryBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -13,6 +16,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Preconditions;
@@ -26,6 +30,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import org.apache.hadoop.fs.RemoteIterator;
 
 /**
  * Stores chunks on HDFS
@@ -118,8 +123,40 @@ public class HDFSStore extends IndexedStore {
 
   @Override
   public void getStoreSummery(Handler<AsyncResult<JsonObject>> handler) {
-    handler.handle(Future.succeededFuture(new JsonObject()));
-    // TODO: start here
+    StoreSummaryBuilder summaryBuilder = new StoreSummaryBuilder();
+
+    vertx.<JsonObject>executeBlocking(f -> {
+      try {
+        synchronized (HDFSStore.this) {
+          FileSystem fs = getFS();
+          RemoteIterator<LocatedFileStatus> files = fs.listFiles(new Path(root), false);
+
+          while (files.hasNext()) {
+            LocatedFileStatus status = files.next();
+            Path filePath = status.getPath();
+            long modificationTime = status.getModificationTime();
+            long size = status.getBlockSize();
+
+            String layer;
+            if (status.isDirectory()) {
+              layer = extractLayer(filePath);
+            } else {
+              layer = "/";
+            }
+
+            summaryBuilder.put(layer, size, modificationTime, 0);
+          }
+
+          f.complete(summaryBuilder.finishBuilding());
+        }
+      } catch (IOException e) {
+        f.fail(e);
+      }
+    }, handler);
+  }
+
+  private String extractLayer(Path path) {
+    return path.toString().substring(root.length());
   }
 
   /**

--- a/georocket-server/src/main/java/io/georocket/storage/mongodb/MongoDBStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/mongodb/MongoDBStore.java
@@ -1,6 +1,7 @@
 package io.georocket.storage.mongodb;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -134,9 +135,9 @@ public class MongoDBStore extends IndexedStore {
 
     getGridFS().find().forEach(file -> {
         summaryBuilder.put(
-          file.getFilename(),
+          extractLayer(file.getFilename()),
           file.getChunkSize(),
-          file.getUploadDate()
+          file.getUploadDate().getTime()
         );
       }, (v, t) -> {
         context.runOnContext(v2 -> {
@@ -147,6 +148,21 @@ public class MongoDBStore extends IndexedStore {
           }
         });
       });
+  }
+
+  private static String extractLayer(String name) {
+    // I expect exactly two types of names
+    // 1) /layer/id
+    // 2) /id
+    // One with two slashes and one only with one.
+    String parts[] = name.split("/");
+
+    // TODO: currently the names are prefixed with "/store"
+    // TODO: pull from georocket upstream master and decrement all numbers by one
+    String layer = parts.length == 3
+      ? "/" : parts.length == 4 ? "/" + parts[2] : null;
+
+    return layer;
   }
 
   @Override

--- a/georocket-server/src/main/java/io/georocket/storage/mongodb/MongoDBStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/mongodb/MongoDBStore.java
@@ -136,7 +136,7 @@ public class MongoDBStore extends IndexedStore {
     getGridFS().find().forEach(file -> {
         summaryBuilder.put(
           extractLayer(file.getFilename()),
-          file.getChunkSize(),
+          file.getLength(),
           file.getUploadDate().getTime()
         );
       }, (v, t) -> {

--- a/georocket-server/src/main/java/io/georocket/storage/s3/S3Store.java
+++ b/georocket-server/src/main/java/io/georocket/storage/s3/S3Store.java
@@ -248,6 +248,12 @@ public class S3Store extends IndexedStore {
   }
 
   @Override
+  public void getStoreSummery(Handler<AsyncResult<JsonObject>> handler) {
+    handler.handle(Future.succeededFuture(new JsonObject()));
+    // TODO: start here
+  }
+
+  @Override
   protected void doDeleteChunks(Queue<String> paths, Handler<AsyncResult<Void>> handler) {
     if (paths.isEmpty()) {
       handler.handle(Future.succeededFuture());

--- a/georocket-server/src/main/java/io/georocket/util/StoreSummaryBuilder.java
+++ b/georocket-server/src/main/java/io/georocket/util/StoreSummaryBuilder.java
@@ -1,0 +1,113 @@
+package io.georocket.util;
+
+import io.vertx.core.json.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * Helper class for {@link io.georocket.storage.Store}
+ *
+ * Build up a summary for a store and his layers.
+ *
+ * @author Andrej Sajenko
+ */
+public class StoreSummaryBuilder {
+  private static Logger log = LoggerFactory.getLogger(StoreSummaryBuilder.class);
+  private static final Date startDate = new Date(0L);
+  private static final DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+  private JsonObject summary = new JsonObject();
+
+  public StoreSummaryBuilder() {
+  }
+
+  /**
+   * Add Chunk information‘s to add to the summary.
+   *
+   * @param fileName The full name of the stored file (including the layer as prefix.
+   *                 The layer may be empty.)
+   *                 The format must be "/layer/id" or "/id".
+   * @param chunkSize The size of this chunk (file stored).
+   * @param lastChange The last modification date of this chunk.
+   *
+   * @return this for fluent calls.
+   */
+  public StoreSummaryBuilder put(String fileName, int chunkSize, Date lastChange) {
+    String layer = extractLayer(fileName);
+
+    JsonObject layerInfo = summary.containsKey(layer)
+      ? summary.getJsonObject(layer) : createEmptyInfo();
+
+    layerInfo.put("size", layerInfo.getInteger("size") + chunkSize);
+    layerInfo.put("lastChange", newestDate(
+      layerInfo.getString("lastChange"), lastChange));
+    layerInfo.put("chunkCount", layerInfo.getInteger("chunkCount") + 1);
+
+    summary.put(layer, layerInfo);
+
+    return this;
+  }
+
+  /**
+   * @return The summary as a json object in the following structure
+   * <code>
+   * {
+   *   "layer": {
+   *     "size": number,
+   *     "lastChange": "yyyy-MM-dd HH:mm:ss",
+   *     "chunkCount": number
+   *   },
+   *   ...
+   * }
+   * </code>
+   */
+  public JsonObject finishBuilding() {
+    return this.summary.copy();
+  }
+
+  private String extractLayer(String name) {
+    // I expect exactly two types of names
+    // 1) /layer/id
+    // 2) /id
+    // One with two slashes and one only with one.
+    String parts[] = name.split("/");
+
+    // TODO: currently the names are prefixed with "/store"
+    // TODO: pull from georocket upstream master and decrement all numbers by one
+    String layer = parts.length == 3
+      ? "/" : parts.length == 4 ? "/" + parts[2] : null;
+
+    if (layer == null) {
+      log.error("Path splitted into " + Arrays.toString(parts));
+    }
+
+    return layer;
+  }
+
+  private String newestDate(String date1, Date date2) {
+    Date dateA;
+    try {
+      dateA = df.parse(date1);
+    } catch (ParseException e) {
+      log.error("Could not parse date: '" + date1 + "', go on with unix start date", e);
+      dateA = startDate;
+    }
+    Date date = dateA.before(date2) ? date2 : dateA;
+
+    return df.format(date);
+  }
+
+  private JsonObject createEmptyInfo() {
+    JsonObject o = new JsonObject();
+    o.put("size", 0);
+    o.put("lastChange", df.format(startDate));
+    o.put("chunkCount", 0);
+    return o;
+  }
+}


### PR DESCRIPTION
I will add the possibility to retrieve some information about the store as a short summary.
So you may see that you have stored some information in GeoRocket.

Currently i used the HEAD HTTP verb on the /store path to get the summary in the response body.

```
HEAD /store HTTP/1.1

HTTP/1.1 200 OK
Content-Length: 101

{"/testLayer1":{"lastChange":"2016-10-05 20:30:31","size":73635840,"chunkCount":282}}
```

But we should think about a another http verb or path, because a GET request on /store will respond with all the chunks which are stored in georocket.

The HTTP specification says that HEAD should return the same header as the GET request.

The verb and the path is easy to change, therefore i will concentrate on the other Store implementations.