### PR TITLE
remove unused map imports

### DIFF
--- a/georocket-server/src/main/java/io/georocket/storage/RxStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/RxStore.java
@@ -5,10 +5,8 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rx.java.ObservableFuture;
 import io.vertx.rx.java.RxHelper;
-import javafx.collections.ObservableMap;
 import rx.Observable;
 
-import java.util.Map;
 
 /**
  * Wraps around {@link Store} and adds methods to be used with RxJava


### PR DESCRIPTION
These unused imports cause errors in my build.

```
RxStore.java:8: error: package javafx.collections does not exist
import javafx.collections.ObservableMap;
                         ^
1 error
 FAILED
```