### PR TITLE
Fix summary

### DIFF
--- a/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
+++ b/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
@@ -74,7 +74,6 @@ public class StoreEndpoint implements Endpoint {
   @Override
   public Router createRouter() {
     Router router = Router.router(vertx);
-    router.get("/?summary").handler(this::onGetSummary);
     router.get("/*").handler(this::onGet);
     router.post("/*").handler(this::onPost);
     router.delete("/*").handler(this::onDelete);
@@ -198,7 +197,14 @@ public class StoreEndpoint implements Endpoint {
    */
   private void onGet(RoutingContext context) {
     String path = getStorePath(context);
-    
+    String summary = context.request().getParam("summary");
+
+    // Client requested only a summary of the store.
+    if (summary != null) {
+      this.onGetSummary(context);
+      return;
+    }
+
     HttpServerResponse response = context.response();
     HttpServerRequest request = context.request();
     String search = request.getParam("search");

--- a/georocket-server/src/main/java/io/georocket/storage/hdfs/HDFSStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/hdfs/HDFSStore.java
@@ -1,11 +1,14 @@
 package io.georocket.storage.hdfs;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Queue;
 
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -35,6 +38,7 @@ import io.vertx.core.json.JsonObject;
  * @author Michel Kraemer
  */
 public class HDFSStore extends IndexedStore {
+  private static Logger log = LoggerFactory.getLogger(HDFSStore.class);
   private final Vertx vertx;
   private final Configuration configuration;
   private final String root;
@@ -147,6 +151,11 @@ public class HDFSStore extends IndexedStore {
 
           f.complete(summaryBuilder.finishBuilding());
         }
+
+      } catch (FileNotFoundException e) {
+        log.warn("Could not read files from store '" + root + "'. This is ok if the system does not contain or" +
+            " never contained data (initial start without use).");
+        f.complete(summaryBuilder.finishBuilding());
       } catch (IOException e) {
         f.fail(e);
       }

--- a/georocket-server/src/main/java/io/georocket/util/StoreSummaryBuilder.java
+++ b/georocket-server/src/main/java/io/georocket/util/StoreSummaryBuilder.java
@@ -14,6 +14,13 @@ public class StoreSummaryBuilder {
   private JsonObject summary = new JsonObject();
 
   /**
+   * Create a store summary with a single entry for the root layer <code>/</code>.
+   */
+  public StoreSummaryBuilder() {
+    summary.put("/", createEmptyInfo());
+  }
+
+  /**
    * Add chunk information to to the summary
    * @param layer the name of the layer containing the chunk. Valid
    * values are <code>/</code>, <code>/name</code> or


### PR DESCRIPTION
* switch to summary generation of the uri contains a query part named "summary"
* check for folder existence first, because it result in an error message if the store is empty and never contained data. I generate a warning because it may be a programming error ... 
* The store summary will return always a entry for the root layer "/", even if the store is empty or was never used. The root layer will be empty.