### PR TITLE
WIP: prefer interface type instead of class

### DIFF
--- a/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java
+++ b/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java
@@ -62,14 +62,8 @@ public class DefaultQueryCompiler implements QueryCompiler {
       this.queryCompilers = queryCompilers;
     }
   }
-  
-  /**
-   * Compile a search string
-   * @param search the search string to compile
-   * @param path the path where to perform the search (may be null if the
-   * whole data store should be searched)
-   * @return the compiled query
-   */
+
+  @Override
   public JsonObject compileQuery(String search, String path) {
     JsonObject qb = compileQuery(search);
     if (path != null && !path.equals("/")) {
@@ -87,7 +81,7 @@ public class DefaultQueryCompiler implements QueryCompiler {
     }
     return qb;
   }
-  
+
   @Override
   public JsonObject compileQuery(String search) {
     if (search == null || search.isEmpty()) {

--- a/georocket-server-api/src/main/java/io/georocket/query/QueryCompiler.java
+++ b/georocket-server-api/src/main/java/io/georocket/query/QueryCompiler.java
@@ -51,4 +51,15 @@ public interface QueryCompiler {
    * @return the query (may be null)
    */
   JsonObject compileQuery(String search);
+
+  /**
+   * <p>Create an Elasticsearch query for the given search string.</p>
+   * <p>Heads up: implementors may use the helper methods from
+   * {@link ElasticsearchQueryHelper} to build the query.</p>
+   * @param search the search string to compile
+   * @param path the path where to perform the search (may be null if the
+   * whole data store should be searched)
+   * @return the query (may be null)
+   */
+  JsonObject compileQuery(String search, String path);
 }

--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.georocket.query.QueryCompiler;
 import org.apache.commons.lang.StringUtils;
 import org.jooq.lambda.Seq;
 import org.jooq.lambda.tuple.Tuple;
@@ -92,7 +93,7 @@ public class IndexerVerticle extends AbstractVerticle {
   /**
    * Compiles search strings to Elasticsearch documents
    */
-  private DefaultQueryCompiler queryCompiler;
+  private QueryCompiler queryCompiler;
   
   /**
    * A list of {@link IndexerFactory} objects


### PR DESCRIPTION
Hi,

should not we use the QueryCompiler Interface as property type instead of the DefaultQueryCompiler type?