### PR TITLE
Remove unnecessary properties from index

### DIFF
--- a/georocket-server/src/main/java/io/georocket/index/generic/DefaultMetaIndexer.java
+++ b/georocket-server/src/main/java/io/georocket/index/generic/DefaultMetaIndexer.java
@@ -24,9 +24,6 @@ public class DefaultMetaIndexer implements MetaIndexer {
   public void onIndexChunk(String path, ChunkMeta chunkMeta,
       IndexMeta indexMeta) {
     result.put("path", path);
-    result.put("correlationId", indexMeta.getCorrelationId());
-    result.put("filename", indexMeta.getFilename());
-    result.put("timestamp", indexMeta.getTimestamp());
     result.put("chunkMeta", chunkMeta.toJsonObject());
     if (indexMeta.getTags() != null) {
       result.put("tags", indexMeta.getTags());


### PR DESCRIPTION
@andrej-sajenko Please review. Are these properties really needed in the index. I can't find them in the `index_defaults.yaml` so I assume they are never really used?