### PR TITLE
WIP: fix: MapUtils::deepMerge for ImmutableMap

### DIFF
--- a/georocket-common/src/main/java/io/georocket/util/MapUtils.java
+++ b/georocket-common/src/main/java/io/georocket/util/MapUtils.java
@@ -1,6 +1,8 @@
 package io.georocket.util;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -37,7 +39,16 @@ public class MapUtils {
           // Don't overwrite an existing value that is equal to the new value.
           // This is useful if we are trying to merge unmodifiable maps.
         } else {
-          m1.put(k, v2);
+          if (v2 instanceof Map) {
+            // Don't copy a map key if it is a Map, because it could be
+            // a immutable Map and the value could be never merged with
+            // other maps.
+            Map<Object, Object> emptyMap = new HashMap<>();
+            deepMerge(emptyMap, (Map<Object, Object>)v2);
+            m1.put(k, (V)emptyMap);
+          } else {
+            m1.put(k, v2);
+          }
         }
       }
     }

--- a/georocket-common/src/test/java/io/georocket/util/MapUtilsTest.java
+++ b/georocket-common/src/test/java/io/georocket/util/MapUtilsTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 /**
@@ -154,6 +155,36 @@ public class MapUtilsTest {
     expected.put("a", "1");
     expected.put("b", Arrays.asList("1", "2"));
     MapUtils.deepMerge(m1, m2);
+    assertEquals(expected, m1);
+  }
+
+  /**
+   * Test if that no immutable map is copied into the destination map.
+   */
+  @Test
+  public void mergeTwoUnmodifiableMaps() {
+    Map<String, Object> m1 = new HashMap<>();
+    Map<String, Object> m2 = ImmutableMap.of(
+        "a", ImmutableMap.of(
+            "a2", "1",
+            "b2", "2"
+        )
+    );
+    Map<String, Object> m3 = ImmutableMap.of(
+        "a", ImmutableMap.of(
+            "a2", "1",
+            "b2", "3"
+        )
+    );
+
+    Map<String, Object> expected = new HashMap<>();
+    Map<String, String> nestedExpected = new HashMap<>();
+    nestedExpected.put("a2", "1");
+    nestedExpected.put("b2", "3");
+    expected.put("a", nestedExpected);
+
+    MapUtils.deepMerge(m1, m2);
+    MapUtils.deepMerge(m1, m3);
     assertEquals(expected, m1);
   }
 }


### PR DESCRIPTION
MapUtils::deepMerge will copy a value of the second argument m2 into the first m1 even if the
value is a ImmutableMap. But if you merge your deepMerge result with another map, the result
will contain a value which is immutable and the merge throw a UnsupportedOperationException.