### PR TITLE
Ensure that DefaultMetaIndexerFactory is first mapping class

### DIFF
--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.georocket.index.generic.DefaultMetaIndexerFactory;
 import org.jooq.lambda.Seq;
 import org.jooq.lambda.tuple.Tuple;
 import org.jooq.lambda.tuple.Tuple2;
@@ -291,8 +292,10 @@ public class IndexerVerticle extends AbstractVerticle {
   private Observable<Void> ensureMapping() {
     // merge mappings from all indexers
     Map<String, Object> mappings = new HashMap<>();
-    indexerFactories.forEach(factory ->
-            MapUtils.deepMerge(mappings, factory.getMapping()));
+    indexerFactories.stream().filter(f -> f instanceof DefaultMetaIndexerFactory)
+        .forEach(factory -> MapUtils.deepMerge(mappings, factory.getMapping()));
+    indexerFactories.stream().filter(f -> !(f instanceof DefaultMetaIndexerFactory))
+        .forEach(factory -> MapUtils.deepMerge(mappings, factory.getMapping()));
 
     return client.putMapping(TYPE_NAME, new JsonObject(mappings)).map(r -> null);
   }

--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.georocket.index.generic.DefaultMetaIndexerFactory;
 import org.jooq.lambda.Seq;
 import org.jooq.lambda.tuple.Tuple;
 import org.jooq.lambda.tuple.Tuple2;
@@ -23,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import io.georocket.constants.AddressConstants;
 import io.georocket.index.elasticsearch.ElasticsearchClient;
 import io.georocket.index.elasticsearch.ElasticsearchClientFactory;
+import io.georocket.index.generic.DefaultMetaIndexerFactory;
 import io.georocket.index.xml.JsonIndexerFactory;
 import io.georocket.index.xml.MetaIndexer;
 import io.georocket.index.xml.MetaIndexerFactory;


### PR DESCRIPTION
MapUtils.deepMerge(...) depends on the input's order. This commit ensures that DefaultMetaIndexerFactory is always the first class to merge.