### PR TITLE
use empty list as default value to avoid null pointer

### DIFF
--- a/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java
+++ b/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java
@@ -44,7 +44,14 @@ public class DefaultQueryCompiler implements QueryCompiler {
   protected Collection<? extends QueryCompiler> queryCompilers;
 
   /**
-   * Set the query compilers
+   * Default constructor
+   */
+  public DefaultQueryCompiler() {
+    this.queryCompilers = Collections.emptyList();
+  }
+
+  /**
+   * Constructs the compiler
    * @param queryCompilers query compilers for individual properties
    */
   public void setQueryCompilers(Collection<? extends QueryCompiler> queryCompilers) {


### PR DESCRIPTION
Use empty list as default value to avoid null pointer in 

`protected JsonObject makeStringQuery(String str)`
`for (QueryCompiler f : queryCompilers) {`