### PR TITLE
Implement count method for Elasticsearch client

### DIFF
--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchClient.java
@@ -133,7 +133,17 @@ public interface ElasticsearchClient {
    */
   Observable<JsonObject> search(String type, JsonObject query,
     JsonObject postFilter, JsonObject aggregations, int size);
-  
+
+  /**
+   * Perform a count operation. The result is the number of documents
+   * matching the query (without the documents themselves). If no query
+   * is given, the total number of documents (of this type) is returned.
+   * @param type the type of the documents to count
+   * @param query the query to send (may be <code>null</code>)
+   * @return the number of documents matching the query
+   */
+  Observable<Long> count(String type, JsonObject query);
+
   /**
    * Delete a number of documents in one bulk request
    * @param type the type of the documents to delete

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/EmbeddedElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/EmbeddedElasticsearchClient.java
@@ -58,6 +58,11 @@ public class EmbeddedElasticsearchClient implements ElasticsearchClient {
   }
 
   @Override
+  public Observable<Long> count(String type, JsonObject query) {
+    return delegate.count(type, query);
+  }
+
+  @Override
   public Observable<JsonObject> bulkDelete(String type, JsonArray ids) {
     return delegate.bulkDelete(type, ids);
   }

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/RemoteElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/RemoteElasticsearchClient.java
@@ -137,6 +137,18 @@ public class RemoteElasticsearchClient implements ElasticsearchClient {
     
     return performRequestRetry(HttpMethod.GET, uri, source.encode());
   }
+
+  @Override
+  public Observable<Long> count(String type, JsonObject query) {
+    String uri = "/" + index + "/" + type + "/_count";
+
+    JsonObject source = new JsonObject();
+    if (query != null) {
+      source.put("query", query);
+    }
+    return performRequestRetry(HttpMethod.GET, uri, source.encode())
+      .map(sr -> sr.getLong("count", 0L));
+  }
   
   @Override
   public Observable<JsonObject> bulkDelete(String type, JsonArray ids) {


### PR DESCRIPTION
Extend Elasticsearch client by a count operation. This request/method returns the number of documents matching the query without returning the documents themselves.