### PR TITLE
Implement a new feature: properties

### DIFF
--- a/georocket-cli/src/main/java/io/georocket/commands/ImportCommand.java
+++ b/georocket-cli/src/main/java/io/georocket/commands/ImportCommand.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.base.Splitter;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -49,6 +50,7 @@ import rx.Observable;
 public class ImportCommand extends AbstractGeoRocketCommand {
   protected List<String> patterns;
   protected List<String> tags;
+  protected List<String> properties;
   protected String layer;
   
   /**
@@ -74,6 +76,21 @@ public class ImportCommand extends AbstractGeoRocketCommand {
       this.tags = Stream.of(tags.split(","))
         .map(t -> t.trim())
         .collect(Collectors.toList());
+    }
+  }
+
+  /**
+   * Set the properties to attach to the imported file
+   * @param properties the properties
+   */
+  @OptionDesc(longName = "properties", shortName = "props",
+      description = "comma-separated list of properties (key:value) to attach to the file(s)",
+      argumentName = "PROPERTIES", argumentType = ArgumentType.STRING)
+  public void setProperties(String properties) {
+    if (properties == null || properties.isEmpty()) {
+      this.properties = null;
+    } else {
+      this.properties = Splitter.on(",").trimResults().splitToList(properties);
     }
   }
   
@@ -260,7 +277,7 @@ public class ImportCommand extends AbstractGeoRocketCommand {
         Handler<AsyncResult<Void>> handler = o.toHandler();
         AsyncFile file = (AsyncFile)f.getLeft().getDelegate();
 
-        WriteStream<Buffer> out = client.getStore().startImport(layer, tags,
+        WriteStream<Buffer> out = client.getStore().startImport(layer, tags, properties,
             Optional.of(f.getRight()), handler);
 
         AtomicBoolean fileClosed = new AtomicBoolean();

--- a/georocket-cli/src/main/java/io/georocket/commands/ImportCommand.java
+++ b/georocket-cli/src/main/java/io/georocket/commands/ImportCommand.java
@@ -176,7 +176,7 @@ public class ImportCommand extends AbstractGeoRocketCommand {
         fs.setDir(new File(root));
         fs.setIncludes(glob);
         DirectoryScanner ds = fs.getDirectoryScanner(project);
-        Arrays.asList(ds.getIncludedFiles()).stream()
+        Arrays.stream(ds.getIncludedFiles())
           .map(path -> Paths.get(root, path).toString())
           .forEach(queue::add);
       }

--- a/georocket-cli/src/test/java/io/georocket/commands/ImportCommandTest.java
+++ b/georocket-cli/src/test/java/io/georocket/commands/ImportCommandTest.java
@@ -154,4 +154,48 @@ public class ImportCommandTest extends CommandTestBase<ImportCommand> {
     
     cmd.run(new String[] { "-t", "hello,world", testFile.getAbsolutePath() }, in, out);
   }
+
+  /**
+   * Test importing with properties
+   * @param context the test context
+   * @throws Exception if something goes wrong
+   */
+  @Test
+  public void importProperties(TestContext context) throws Exception {
+    String url = "/store?props=hello%3Aworld%2CmyKey%3AmyValue";
+    stubFor(post(urlEqualTo(url))
+        .willReturn(aResponse()
+            .withStatus(202)));
+
+    Async async = context.async();
+    cmd.setEndHandler(exitCode -> {
+      context.assertEquals(0, exitCode);
+      verifyPosted(url, XML, context);
+      async.complete();
+    });
+
+    cmd.run(new String[] { "-props", "hello:world,myKey:myValue", testFile.getAbsolutePath() }, in, out);
+  }
+
+  /**
+   * Test importing with properties including an escaped character
+   * @param context the test context
+   * @throws Exception if something goes wrong
+   */
+  @Test
+  public void importPropertiesEscaping(TestContext context) throws Exception {
+    String url = "/store?props=hello%3Aworld%2CmyKey%3Amy%5C%3AValue%2Cmy%5C%3AKey%3AmyValue";
+    stubFor(post(urlEqualTo(url))
+        .willReturn(aResponse()
+            .withStatus(202)));
+
+    Async async = context.async();
+    cmd.setEndHandler(exitCode -> {
+      context.assertEquals(0, exitCode);
+      verifyPosted(url, XML, context);
+      async.complete();
+    });
+
+    cmd.run(new String[] { "-props", "hello:world,myKey:my\\:Value,my\\:Key:myValue", testFile.getAbsolutePath() }, in, out);
+  }
 }

--- a/georocket-client-api/src/test/java/io/georocket/client/StoreClientImportTest.java
+++ b/georocket-client-api/src/test/java/io/georocket/client/StoreClientImportTest.java
@@ -127,4 +127,47 @@ public class StoreClientImportTest extends StoreClientTestBase {
     }));
     w.end(Buffer.buffer(XML));
   }
+
+  /**
+   * Test importing properties
+   * @param context the test context
+   * @throws Exception if something goes wrong
+   */
+  @Test
+  public void importProperties(TestContext context) throws Exception {
+    String url = "/store?props=hello%3Aworld%2Ckey%3Avalue";
+    stubFor(post(urlEqualTo(url))
+        .willReturn(aResponse()
+            .withStatus(202)));
+
+    Async async = context.async();
+    WriteStream<Buffer> w = client.getStore().startImport(null, null,
+        Arrays.asList("hello:world", "key:value"), context.asyncAssertSuccess(v -> {
+      verifyPosted(url, XML, context);
+      async.complete();
+    }));
+    w.end(Buffer.buffer(XML));
+  }
+
+  /**
+   * Test importing tags and properties
+   * @param context the test context
+   * @throws Exception if something goes wrong
+   */
+  @Test
+  public void importTagsAndProperties(TestContext context) throws Exception {
+    String url = "/store?tags=testTag,testTag2&props=hello%3Awo%5C%3Arld%2Challo2%3Aworld2";
+    stubFor(post(urlEqualTo(url))
+        .willReturn(aResponse()
+            .withStatus(202)));
+
+    Async async = context.async();
+    WriteStream<Buffer> w = client.getStore().startImport(null,
+      Arrays.asList("testTag", "testTag2"), Arrays.asList("hello:wo\\:rld", "hallo2:world2"),
+    context.asyncAssertSuccess(v -> {
+      verifyPosted(url, XML, context);
+      async.complete();
+    }));
+    w.end(Buffer.buffer(XML));
+  }
 }

--- a/georocket-client-api/src/test/java/io/georocket/client/StoreClientImportTest.java
+++ b/georocket-client-api/src/test/java/io/georocket/client/StoreClientImportTest.java
@@ -156,7 +156,7 @@ public class StoreClientImportTest extends StoreClientTestBase {
    */
   @Test
   public void importTagsAndProperties(TestContext context) throws Exception {
-    String url = "/store?tags=testTag,testTag2&props=hello%3Awo%5C%3Arld%2Challo2%3Aworld2";
+    String url = "/store?tags=testTag%2CtestTag2&props=hello%3Awo%5C%3Arld%2Challo2%3Aworld2";
     stubFor(post(urlEqualTo(url))
         .willReturn(aResponse()
             .withStatus(202)));

--- a/georocket-server-api/src/main/java/io/georocket/storage/IndexMeta.java
+++ b/georocket-server-api/src/main/java/io/georocket/storage/IndexMeta.java
@@ -1,6 +1,7 @@
 package io.georocket.storage;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Metadata affecting the way a chunk is indexed
@@ -9,6 +10,7 @@ import java.util.List;
  */
 public class IndexMeta {
   private final List<String> tags;
+  private final Map<String, Object> properties;
   private final String fallbackCRSString;
   private final String correlationId;
   private final String filename;
@@ -21,7 +23,7 @@ public class IndexMeta {
    * @param timestamp the timestamp for this import
    */
   public IndexMeta(String correlationId, String filename, long timestamp) {
-    this(correlationId, filename, timestamp, null, null);
+    this(correlationId, filename, timestamp, null, null, null);
   }
   
   /**
@@ -30,10 +32,11 @@ public class IndexMeta {
    * @param filename the name of the source file containing the chunks to be indexed
    * @param timestamp the timestamp for this import
    * @param tags the list of tags to attach to the chunk (may be null)
+   * @param properties the map of properties to attach to the chunk (may be null)
    */
   public IndexMeta(String correlationId, String filename, long timestamp,
-      List<String> tags) {
-    this(correlationId, filename, timestamp, tags, null);
+      List<String> tags, Map<String, Object> properties) {
+    this(correlationId, filename, timestamp, tags, properties, null);
   }
   
   /**
@@ -42,16 +45,18 @@ public class IndexMeta {
    * @param filename the name of the source file containing the chunks to be indexed
    * @param timestamp the timestamp for this import
    * @param tags the list of tags to attach to the chunk (may be null)
+   * @param properties the map of properties to attach to the chunk (may be null)
    * @param fallbackCRSString a string representing the CRS that should be used
    * to index the chunk to import if it does not specify a CRS itself (may be
    * null if no CRS is available as fallback)
    */
   public IndexMeta(String correlationId, String filename, long timestamp,
-      List<String> tags, String fallbackCRSString) {
+      List<String> tags, Map<String, Object> properties, String fallbackCRSString) {
     this.correlationId = correlationId;
     this.filename = filename;
     this.timestamp = timestamp;
     this.tags = tags;
+    this.properties = properties;
     this.fallbackCRSString = fallbackCRSString;
   }
 
@@ -81,6 +86,13 @@ public class IndexMeta {
    */
   public List<String> getTags() {
     return tags;
+  }
+
+  /**
+   * @return the map of properties to attach to the chunk (may be null)
+   */
+  public Map<String, Object> getProperties() {
+    return properties;
   }
   
   /**

--- a/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
+++ b/georocket-server/src/main/java/io/georocket/http/StoreEndpoint.java
@@ -262,14 +262,16 @@ public class StoreEndpoint implements Endpoint {
     List<String> tags = tagsStr != null ? Splitter.on(',')
         .trimResults().splitToList(tagsStr) : null;
 
-    String regex = "(?<!" + Pattern.quote("\\") + ")" + Pattern.quote(":");
     Map<String, Object> properties = new HashMap<>();
-    Stream.of(propertiesStr.split(","))
-      .map(String::trim)
-      .map(property -> property.split(regex))
-      .filter(parts -> parts.length == 2)
-      .forEach(property -> properties.put(StringEscapeUtils.unescapeJava(property[0].trim()), StringEscapeUtils.unescapeJava(property[1].trim())));
 
+    if (propertiesStr != null && !propertiesStr.isEmpty()) {
+      String regex = "(?<!" + Pattern.quote("\\") + ")" + Pattern.quote(":");
+      Stream.of(propertiesStr.split(","))
+              .map(String::trim)
+              .map(property -> property.split(regex))
+              .filter(parts -> parts.length == 2)
+              .forEach(property -> properties.put(StringEscapeUtils.unescapeJava(property[0].trim()), StringEscapeUtils.unescapeJava(property[1].trim())));
+    }
     // get temporary filename
     String incoming = storagePath + "/incoming";
     String filename = new ObjectId().toString();

--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -556,6 +556,10 @@ public class IndexerVerticle extends AbstractVerticle {
         List<String> tags = tagsArr != null ? tagsArr.stream().flatMap(o -> o != null ?
                 Stream.of(o.toString()) : Stream.of()).collect(Collectors.toList()) : null;
 
+        // get properties
+        JsonObject propertiesObj = body.getJsonObject("properties");
+        Map<String, Object> properties = propertiesObj != null ? propertiesObj.getMap() : null;
+
         // get fallback CRS
         String fallbackCRSString = body.getString("fallbackCRSString");
 
@@ -567,7 +571,7 @@ public class IndexerVerticle extends AbstractVerticle {
 
         ChunkMeta chunkMeta = getMeta(meta);
         IndexMeta indexMeta = new IndexMeta(correlationId, filename, timestamp,
-            tags, fallbackCRSString);
+            tags, properties, fallbackCRSString);
 
         // open chunk and create IndexRequest
         return openChunkToDocument(path, chunkMeta, indexMeta)

--- a/georocket-server/src/main/java/io/georocket/index/generic/DefaultMetaIndexer.java
+++ b/georocket-server/src/main/java/io/georocket/index/generic/DefaultMetaIndexer.java
@@ -28,5 +28,8 @@ public class DefaultMetaIndexer implements MetaIndexer {
     if (indexMeta.getTags() != null) {
       result.put("tags", indexMeta.getTags());
     }
+    if (indexMeta.getProperties() != null) {
+      result.put("props", indexMeta.getProperties());
+    }
   }
 }

--- a/georocket-server/src/main/java/io/georocket/storage/indexed/IndexedStore.java
+++ b/georocket-server/src/main/java/io/georocket/storage/indexed/IndexedStore.java
@@ -50,12 +50,17 @@ public abstract class IndexedStore implements Store {
             .put("filename", indexMeta.getFilename())
             .put("timestamp", indexMeta.getTimestamp());
 
-        if (indexMeta != null && indexMeta.getTags() != null) {
+        if (indexMeta.getTags() != null) {
           indexMsg.put("tags", new JsonArray(indexMeta.getTags()));
         }
-        if (indexMeta != null && indexMeta.getFallbackCRSString() != null) {
+        if (indexMeta.getFallbackCRSString() != null) {
           indexMsg.put("fallbackCRSString", indexMeta.getFallbackCRSString());
         }
+
+        if (indexMeta.getProperties() != null) {
+          indexMsg.put("properties", new JsonObject(indexMeta.getProperties()));
+        }
+
         vertx.eventBus().send(AddressConstants.INDEXER_ADD, indexMsg);
         
         // tell sender that writing was successful

--- a/georocket-server/src/main/resources/io/georocket/index/generic/index_defaults.yaml
+++ b/georocket-server/src/main/resources/io/georocket/index/generic/index_defaults.yaml
@@ -7,6 +7,13 @@ variables:
     type: keyword
     index: "no"
 
+dynamic_templates:
+  # properties attached to chunks
+  - propsFields:
+      path_match: props.*
+      mapping:
+        type: keyword
+
 # Properties to index
 properties:
   # path to the chunk

--- a/georocket-server/src/test/java/io/georocket/storage/StorageTest.java
+++ b/georocket-server/src/test/java/io/georocket/storage/StorageTest.java
@@ -2,7 +2,9 @@ package io.georocket.storage;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
 import org.bson.types.ObjectId;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,6 +96,11 @@ abstract public class StorageTest {
    * Test data: a sample tag list for an Store::add method
    */
   protected final static List<String> TAGS = Arrays.asList("a", "b", "c");
+
+  /**
+   * Test data: a sample property map for an Store::add method
+   */
+  protected final static Map<String, Object> PROPERTIES = ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3");
 
   /**
    * Test data: a randomly generated id for all tests.
@@ -403,6 +410,7 @@ abstract public class StorageTest {
 
       context.assertEquals(META.toJsonObject(), index.getJsonObject("meta"));
       context.assertEquals(new JsonArray(TAGS), index.getJsonArray("tags"));
+      context.assertEquals(new JsonObject(PROPERTIES), index.getJsonObject("properties"));
       context.assertEquals(FALLBACK_CRS_STRING, index.getString("fallbackCRSString"));
 
       asyncIndexerAdd.complete();
@@ -418,7 +426,7 @@ abstract public class StorageTest {
       context.fail("Indexer should not be notified for a query event after"
           + "Store::add was called!"));
 
-    IndexMeta indexMeta = new IndexMeta(IMPORT_ID, ID, TIMESTAMP, TAGS, FALLBACK_CRS_STRING);
+    IndexMeta indexMeta = new IndexMeta(IMPORT_ID, ID, TIMESTAMP, TAGS, PROPERTIES, FALLBACK_CRS_STRING);
     store.add(CHUNK_CONTENT, META, path, indexMeta, context.asyncAssertSuccess(err -> {
       validateAfterStoreAdd(context, vertx, path, context.asyncAssertSuccess(v -> {
         asyncAdd.complete();

--- a/georocket-server/src/test/resources/io/georocket/query/fixtures/eq.json
+++ b/georocket-server/src/test/resources/io/georocket/query/fixtures/eq.json
@@ -2,8 +2,16 @@
   "query": "EQ(foo bar)",
   "queryCompilers": ["io.georocket.index.xml.XMLGenericAttributeIndexerFactory"],
   "expected": {
-    "term": {
-      "genAttrs.foo": "bar"
+    "bool" : {
+      "should" : [ {
+        "term" : {
+          "genAttrs.foo" : "bar"
+        }
+      }, {
+        "term" : {
+          "props.foo" : "bar"
+        }
+      } ]
     }
   }
 }


### PR DESCRIPTION
Users can add properties to their import. These are stored in Elasticsearch using a new field "props". In case users are searching EQ(key value), the properties are queried. In case users provide a single value only OR(k1, k2), the tags are queried.