### PR TITLE
fix: encoding

### DIFF
--- a/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java
+++ b/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java
@@ -122,7 +122,7 @@ public class DefaultQueryCompiler implements QueryCompiler {
 
   /**
    * <p>Create an Elasticsearch query for the given search string but does
-   * not apply the {@link ElasticsearchQueryOptimizer} to it.</p>
+   * not apply the {@link ElasticsearchQueryOptimizer} to it.</p>
    * @param search the search string
    * @return the Elasticsearch query (may be null)
    */


### PR DESCRIPTION
Replace unmappable character

```bash
/georocket/georocket-common/src/main/java/io/georocket/query/DefaultQueryCompiler.java:125: error: unmappable character for encoding ASCII
   * not apply the {@link ElasticsearchQueryOptimizer}??to it.
```