### PR TITLE
Recognize environment variables in the format GEOROCKT_HOME

### DIFF
--- a/georocket-server/src/main/java/io/georocket/GeoRocket.java
+++ b/georocket-server/src/main/java/io/georocket/GeoRocket.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.georocket.http.Endpoint;
 import io.georocket.http.GeneralEndpoint;
@@ -310,10 +312,17 @@ public class GeoRocket extends AbstractVerticle {
    * @param conf The config
    */
   private static void overwriteWithEnvironmentVariables(JsonObject conf) {
+    Map<String, String> names = ConfigConstants.getConfigKeys()
+      .stream()
+      .collect(Collectors.toMap(
+        s -> s.toUpperCase().replace(".", "_"), 
+        Function.identity()
+      ));
     System.getenv().forEach((key, val) -> {
-      if (key.startsWith("georocket")) {
+      String name = names.get(key.toUpperCase());
+      if (name != null) {
         Object newVal = toJsonType(val);
-        conf.put(key, newVal);
+        conf.put(name, newVal);
       }
     });
   }

--- a/georocket-server/src/main/java/io/georocket/GeoRocket.java
+++ b/georocket-server/src/main/java/io/georocket/GeoRocket.java
@@ -307,18 +307,32 @@ public class GeoRocket extends AbstractVerticle {
   }
 
   /**
-   * Look up all environment variables and take all variables with the prefix
-   * <code>georocket</code>. Parse the value and put it into the config. Replace existing key entries.
-   * @param conf The config
+   * Match every environment variable against the config keys from
+   * {{@link ConfigConstants#getConfigKeys()}} and save the found values using
+   * the config key in the config object. The method is equivalent to calling
+   * <code>overwriteWithEnvironmentVariables(conf, java.lang.System.getenv())</code>
+   * @param conf the config object
    */
   private static void overwriteWithEnvironmentVariables(JsonObject conf) {
+    overwriteWithEnvironmentVariables(conf, System.getenv());
+  }
+
+  /**
+   * Match every environment variable against the config keys from
+   * {{@link ConfigConstants#getConfigKeys()}} and save the found values using
+   * the config key in the config object.
+   * @param conf the config object
+   * @param env the map with the environment variables
+   */
+  static void overwriteWithEnvironmentVariables(JsonObject conf,
+    Map<String, String> env) {
     Map<String, String> names = ConfigConstants.getConfigKeys()
       .stream()
       .collect(Collectors.toMap(
-        s -> s.toUpperCase().replace(".", "_"), 
+        s -> s.toUpperCase().replace(".", "_"),
         Function.identity()
       ));
-    System.getenv().forEach((key, val) -> {
+    env.forEach((key, val) -> {
       String name = names.get(key.toUpperCase());
       if (name != null) {
         Object newVal = toJsonType(val);

--- a/georocket-server/src/main/java/io/georocket/constants/ConfigConstants.java
+++ b/georocket-server/src/main/java/io/georocket/constants/ConfigConstants.java
@@ -53,6 +53,11 @@ public final class ConfigConstants {
     // hidden constructor
   }
 
+  /**
+   * Get all configuration keys by enumerating over all string constants beginning
+   * with the prefix <code>georocket</code>
+   * @return the list of configuration keys
+   */
   public static List<String> getConfigKeys() {
     return Arrays.stream(ConfigConstants.class.getFields())
       .map(f -> {

--- a/georocket-server/src/main/java/io/georocket/constants/ConfigConstants.java
+++ b/georocket-server/src/main/java/io/georocket/constants/ConfigConstants.java
@@ -1,5 +1,9 @@
 package io.georocket.constants;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Configuration constants
  * @author Michel Kraemer
@@ -47,5 +51,20 @@ public final class ConfigConstants {
   
   private ConfigConstants() {
     // hidden constructor
+  }
+
+  public static List<String> getConfigKeys() {
+    return Arrays.stream(ConfigConstants.class.getFields())
+      .map(f -> {
+        try {
+          return f.get(null);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException("Could not access config constant", e);
+        }
+      })
+      .filter(s -> s instanceof String)
+      .map(String.class::cast)
+      .filter(s -> s.startsWith("georocket"))
+      .collect(Collectors.toList());
   }
 }

--- a/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
+++ b/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
@@ -3,13 +3,12 @@ package io.georocket;
 import com.google.common.collect.Sets;
 import io.georocket.constants.ConfigConstants;
 import io.vertx.core.json.JsonObject;
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test {@link GeoRocket}
@@ -31,7 +30,7 @@ public class GeoRocketTest {
       put(ENV_KEY, VALUE);
     }};
     GeoRocket.overwriteWithEnvironmentVariables(conf, env);
-    Assert.assertEquals(Sets.newHashSet(PROP_KEY), conf.getMap().keySet());
-    Assert.assertEquals(VALUE, conf.getString(PROP_KEY));
+    assertEquals(Sets.newHashSet(PROP_KEY), conf.getMap().keySet());
+    assertEquals(VALUE, conf.getString(PROP_KEY));
   }
 }

--- a/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
+++ b/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
@@ -16,6 +16,9 @@ import java.util.Map;
  * @author Tim Hellhake
  */
 public class GeoRocketTest {
+  /**
+   * Test if the configuration values are overwritten by environment values
+   */
   @Test
   public void testOverwriteWithEnvironmentVariables() {
     final String PROP_KEY = ConfigConstants.LOG_CONFIG;

--- a/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
+++ b/georocket-server/src/test/java/io/georocket/GeoRocketTest.java
@@ -1,0 +1,34 @@
+package io.georocket;
+
+import com.google.common.collect.Sets;
+import io.georocket.constants.ConfigConstants;
+import io.vertx.core.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test {@link GeoRocket}
+ * @author Tim Hellhake
+ */
+public class GeoRocketTest {
+  @Test
+  public void testOverwriteWithEnvironmentVariables() {
+    final String PROP_KEY = ConfigConstants.LOG_CONFIG;
+    final String ENV_KEY = PROP_KEY
+      .replace(".", "_")
+      .toUpperCase();
+    final String VALUE = "test";
+    JsonObject conf = new JsonObject();
+    Map<String, String> env = new HashMap<String, String>() {{
+      put(ENV_KEY, VALUE);
+    }};
+    GeoRocket.overwriteWithEnvironmentVariables(conf, env);
+    Assert.assertEquals(Sets.newHashSet(PROP_KEY), conf.getMap().keySet());
+    Assert.assertEquals(VALUE, conf.getString(PROP_KEY));
+  }
+}


### PR DESCRIPTION
Some shells do not support environment variables in the format `georocket.home`.
Therefore georocket should also recognize them as upper case strings with the dots are replaced by underscores (`GEOROCKT_HOME`).