### PR TITLE
added getMapping method to ES Client

### DIFF
--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchClient.java
@@ -223,7 +223,22 @@ public interface ElasticsearchClient {
    * been created or if it already exists
    */
   Observable<Void> ensureMapping(String type, JsonObject mapping);
-  
+
+  /**
+   * Get mapping for the given type
+   * @param type the type
+   * @return the parsed mapping response from the server
+   */
+  Observable<JsonObject> getMapping(String type);
+
+  /**
+   * Get mapping for the given type
+   * @param type the type
+   * @param field the field
+   * @return the parsed mapping response from the server
+   */
+  Observable<JsonObject> getMapping(String type, String field);
+
   /**
    * Check if Elasticsearch is running and if it answers to a simple request
    * @return <code>true</code> if Elasticsearch is running, <code>false</code>

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/EmbeddedElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/EmbeddedElasticsearchClient.java
@@ -102,6 +102,16 @@ public class EmbeddedElasticsearchClient implements ElasticsearchClient {
   public Observable<Boolean> putMapping(String type, JsonObject mapping) {
     return delegate.putMapping(type, mapping);
   }
+
+  @Override
+  public Observable<JsonObject> getMapping(String type) {
+    return delegate.getMapping(type);
+  }
+
+  @Override
+  public Observable<JsonObject> getMapping(String type, String field) {
+    return delegate.getMapping(type, field);
+  }
   
   @Override
   public Observable<Void> ensureMapping(String type, JsonObject mapping) {

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/RemoteElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/RemoteElasticsearchClient.java
@@ -292,7 +292,21 @@ public class RemoteElasticsearchClient implements ElasticsearchClient {
       }
     });
   }
-  
+
+  @Override
+  public Observable<JsonObject> getMapping(String type) {
+    return getMapping(type, null);
+  }
+
+  @Override
+  public Observable<JsonObject> getMapping(String type, String field) {
+    String uri = "/" + index + "/_mapping/" + type;
+    if (field != null) {
+      uri += "/field/" + field;
+    }
+    return performRequestRetry(HttpMethod.GET, uri, "");
+  }
+
   @Override
   public Observable<Boolean> isRunning() {
     HttpClientRequest req = client.head("/");


### PR DESCRIPTION
added a method to fetch the ES mapping for corresponding type and field.
This is needed for a autocompletion filter on generated feature Properties.