### PR TITLE
use single when observable emits only one item and extend ES API

### DIFF
--- a/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
+++ b/georocket-server/src/main/java/io/georocket/index/IndexerVerticle.java
@@ -56,6 +56,7 @@ import io.vertx.rxjava.core.AbstractVerticle;
 import io.vertx.rxjava.core.eventbus.Message;
 import rx.Observable;
 import rx.Observable.Operator;
+import rx.Single;
 import rx.functions.Func1;
 
 /**
@@ -163,7 +164,7 @@ public class IndexerVerticle extends AbstractVerticle {
     queryCompiler.setQueryCompilers(indexerFactories);
     
     new ElasticsearchClientFactory(vertx).createElasticsearchClient(INDEX_NAME)
-      .doOnNext(es -> {
+      .doOnSuccess(es -> {
         client = es;
       })
       .flatMap(v -> client.ensureIndex())
@@ -322,7 +323,7 @@ public class IndexerVerticle extends AbstractVerticle {
     }
   }
   
-  private Observable<Void> ensureMapping() {
+  private Single<Void> ensureMapping() {
     // merge mappings from all indexers
     Map<String, Object> mappings = new HashMap<>();
     indexerFactories.stream().filter(f -> f instanceof DefaultMetaIndexerFactory)
@@ -358,7 +359,7 @@ public class IndexerVerticle extends AbstractVerticle {
       .map(Tuple3::v3)
       .toList();
     
-    return client.bulkInsert(type, docsToInsert).flatMap(bres -> {
+    return client.bulkInsert(type, docsToInsert).flatMapObservable(bres -> {
       JsonArray items = bres.getJsonArray("items");
       for (int i = 0; i < items.size(); ++i) {
         JsonObject jo = items.getJsonObject(i);
@@ -613,7 +614,7 @@ public class IndexerVerticle extends AbstractVerticle {
    * @param body the message containing the query
    * @return an observable that emits the results of the query
    */
-  private Observable<JsonObject> onQuery(JsonObject body) {
+  private Single<JsonObject> onQuery(JsonObject body) {
     String search = body.getString("search");
     String path = body.getString("path");
     String scrollId = body.getString("scrollId");
@@ -623,7 +624,7 @@ public class IndexerVerticle extends AbstractVerticle {
     JsonObject parameters = new JsonObject()
       .put("size", pageSize);
 
-    Observable<JsonObject> observable;
+    Single<JsonObject> single;
     if (scrollId == null) {
       // Execute a new search. Use a post_filter because we only want to get
       // a yes/no answer and no scoring (i.e. we only want to get matching
@@ -633,15 +634,15 @@ public class IndexerVerticle extends AbstractVerticle {
       try {
         postFilter = queryCompiler.compileQuery(search, path);
       } catch (Throwable t) {
-        return Observable.error(t);
+        return Single.error(t);
       }
-      observable = client.beginScroll(TYPE_NAME, null, postFilter, parameters, timeout);
+      single = client.beginScroll(TYPE_NAME, null, postFilter, parameters, timeout);
     } else {
       // continue searching
-      observable = client.continueScroll(scrollId, timeout);
+      single = client.continueScroll(scrollId, timeout);
     }
 
-    return observable.map(sr -> {
+    return single.map(sr -> {
       // iterate through all hits and convert them to JSON
       JsonObject hits = sr.getJsonObject("hits");
       long totalHits = hits.getLong("total");
@@ -672,7 +673,7 @@ public class IndexerVerticle extends AbstractVerticle {
    * @return an observable that emits a single item when the chunks have
    * been deleted successfully
    */
-  private Observable<Void> onDelete(JsonObject body) {
+  private Single<Void> onDelete(JsonObject body) {
     JsonArray paths = body.getJsonArray("paths");
 
     // execute bulk request
@@ -686,11 +687,11 @@ public class IndexerVerticle extends AbstractVerticle {
         log.error("One or more chunks could not be deleted");
         log.error(error);
         onDeletingFinished(stopTimeStamp - startTimeStamp, paths, error);
-        return Observable.error(new NoStackTraceThrowable(
+        return Single.error(new NoStackTraceThrowable(
                 "One or more chunks could not be deleted"));
       } else {
         onDeletingFinished(stopTimeStamp - startTimeStamp, paths, null);
-        return Observable.just(null);
+        return Single.just(null);
       }
     });
   }

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchClient.java
@@ -6,7 +6,7 @@ import org.jooq.lambda.tuple.Tuple2;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import rx.Observable;
+import rx.Single;
 
 /**
  * An Elasticsearch client
@@ -26,7 +26,7 @@ public interface ElasticsearchClient {
    * @see #bulkResponseHasErrors(JsonObject)
    * @see #bulkResponseGetErrorMessage(JsonObject)
    */
-  Observable<JsonObject> bulkInsert(String type,
+  Single<JsonObject> bulkInsert(String type,
       List<Tuple2<String, JsonObject>> documents);
   
   /**
@@ -38,7 +38,7 @@ public interface ElasticsearchClient {
    * @return an object containing the search hits and a scroll id that can
    * be passed to {@link #continueScroll(String, String)} to get more results
    */
-  default Observable<JsonObject> beginScroll(String type, JsonObject query,
+  default Single<JsonObject> beginScroll(String type, JsonObject query,
       JsonObject parameters, String timeout) {
     return beginScroll(type, query, null, parameters, timeout);
   }
@@ -57,7 +57,7 @@ public interface ElasticsearchClient {
    * @return an object containing the search hits and a scroll id that can
    * be passed to {@link #continueScroll(String, String)} to get more results
    */
-  default Observable<JsonObject> beginScroll(String type, JsonObject query,
+  default Single<JsonObject> beginScroll(String type, JsonObject query,
       JsonObject postFilter, JsonObject parameters, String timeout) {
     return beginScroll(type, query, postFilter, null, parameters, timeout);
   }
@@ -77,7 +77,7 @@ public interface ElasticsearchClient {
    * @return an object containing the search hits and a scroll id that can
    * be passed to {@link #continueScroll(String, String)} to get more results
    */
-  Observable<JsonObject> beginScroll(String type, JsonObject query,
+  Single<JsonObject> beginScroll(String type, JsonObject query,
       JsonObject postFilter, JsonObject aggregations, JsonObject parameters, String timeout);
   
   /**
@@ -87,7 +87,7 @@ public interface ElasticsearchClient {
    * @param timeout the time after which the scroll id becomes invalid
    * @return an object containing new search hits and possibly a new scroll id
    */
-  Observable<JsonObject> continueScroll(String scrollId, String timeout);
+  Single<JsonObject> continueScroll(String scrollId, String timeout);
   
   /**
    * Perform a search. The result set might not contain all documents. If you
@@ -99,7 +99,7 @@ public interface ElasticsearchClient {
    * @param parameters the elasticsearch parameters
    * @return an object containing the search result as returned from Elasticsearch
    */
-  default Observable<JsonObject> search(String type, JsonObject query, JsonObject parameters) {
+  default Single<JsonObject> search(String type, JsonObject query, JsonObject parameters) {
     return search(type, query, null, null, parameters);
   }
   
@@ -114,7 +114,7 @@ public interface ElasticsearchClient {
    * @param parameters the elasticsearch parameters
    * @return an object containing the search result as returned from Elasticsearch
    */
-  default Observable<JsonObject> search(String type, JsonObject query,
+  default Single<JsonObject> search(String type, JsonObject query,
     JsonObject postFilter, JsonObject parameters) {
     return search(type, query, postFilter, null, parameters);
   }
@@ -131,7 +131,7 @@ public interface ElasticsearchClient {
    * @param parameters the elasticsearch parameters
    * @return an object containing the search result as returned from Elasticsearch
    */
-  Observable<JsonObject> search(String type, JsonObject query,
+  Single<JsonObject> search(String type, JsonObject query,
     JsonObject postFilter, JsonObject aggregations, JsonObject parameters);
 
   /**
@@ -142,7 +142,7 @@ public interface ElasticsearchClient {
    * @param query the query to send (may be <code>null</code>)
    * @return the number of documents matching the query
    */
-  Observable<Long> count(String type, JsonObject query);
+  Single<Long> count(String type, JsonObject query);
 
   /**
    * Perform an update operation. The update script is applied to all
@@ -152,7 +152,7 @@ public interface ElasticsearchClient {
    * @param script the update script to apply
    * @return an object containing the search result as returned from Elasticsearch
    */
-  Observable<JsonObject> updateByQuery(String type, JsonObject postFilter,
+  Single<JsonObject> updateByQuery(String type, JsonObject postFilter,
     JsonObject script);
 
   /**
@@ -163,55 +163,55 @@ public interface ElasticsearchClient {
    * @see #bulkResponseHasErrors(JsonObject)
    * @see #bulkResponseGetErrorMessage(JsonObject)
    */
-  Observable<JsonObject> bulkDelete(String type, JsonArray ids);
+  Single<JsonObject> bulkDelete(String type, JsonArray ids);
 
   /**
    * Check if the index exists
-   * @return an observable emitting <code>true</code> if the index exists or
+   * @return an single emitting <code>true</code> if the index exists or
    * <code>false</code> otherwise
    */
-  Observable<Boolean> indexExists();
+  Single<Boolean> indexExists();
 
   /**
    * Check if the type of the index exists
    * @param type the type
-   * @return an observable emitting <code>true</code> if the type of
+   * @return an single emitting <code>true</code> if the type of
    * the index exists or <code>false</code> otherwise
    */
-  Observable<Boolean> typeExists(String type);
+  Single<Boolean> typeExists(String type);
 
   /**
    * Create the index
-   * @return an observable emitting <code>true</code> if the index creation
+   * @return an single emitting <code>true</code> if the index creation
    * was acknowledged by Elasticsearch, <code>false</code> otherwise
    */
-  Observable<Boolean> createIndex();
+  Single<Boolean> createIndex();
 
   /**
    * Create the index with settings.
    * @param settings the settings to set for the index.
-   * @return an observable emitting <code>true</code> if the index creation
+   * @return an single emitting <code>true</code> if the index creation
    * was acknowledged by Elasticsearch, <code>false</code> otherwise
    */
-  Observable<Boolean> createIndex(JsonObject settings);
+  Single<Boolean> createIndex(JsonObject settings);
   
   /**
    * Convenience method that makes sure the index exists. It first calls
    * {@link #indexExists()} and then {@link #createIndex()} if the index does
    * not exist yet.
-   * @return an observable that will emit a single item when the index has
+   * @return an single that will emit a single item when the index has
    * been created or if it already exists
    */
-  Observable<Void> ensureIndex();
+  Single<Void> ensureIndex();
   
   /**
    * Add mapping for the given type
    * @param type the type
    * @param mapping the mapping to set for the type
-   * @return an observable emitting <code>true</code> if the operation
+   * @return an single emitting <code>true</code> if the operation
    * was acknowledged by Elasticsearch, <code>false</code> otherwise
    */
-  Observable<Boolean> putMapping(String type, JsonObject mapping);
+  Single<Boolean> putMapping(String type, JsonObject mapping);
   
   /**
    * Convenience method that makes sure the given mapping exists. It first calls
@@ -219,17 +219,17 @@ public interface ElasticsearchClient {
    * if the mapping does not exist yet.
    * @param type the target type for the mapping
    * @param mapping the mapping to set for the type
-   * @return an observable that will emit a single item when the mapping has
+   * @return a single that will emit a single item when the mapping has
    * been created or if it already exists
    */
-  Observable<Void> ensureMapping(String type, JsonObject mapping);
+  Single<Void> ensureMapping(String type, JsonObject mapping);
 
   /**
    * Get mapping for the given type
    * @param type the type
    * @return the parsed mapping response from the server
    */
-  Observable<JsonObject> getMapping(String type);
+  Single<JsonObject> getMapping(String type);
 
   /**
    * Get mapping for the given type
@@ -237,14 +237,95 @@ public interface ElasticsearchClient {
    * @param field the field
    * @return the parsed mapping response from the server
    */
-  Observable<JsonObject> getMapping(String type, String field);
-
+  Single<JsonObject> getMapping(String type, String field);
   /**
    * Check if Elasticsearch is running and if it answers to a simple request
    * @return <code>true</code> if Elasticsearch is running, <code>false</code>
    * otherwise
    */
-  Observable<Boolean> isRunning();
+  Single<Boolean> isRunning();
+
+  /**
+   * Create a new alias to an index.
+   * @param alias Alias name.
+   * @param index Index name.
+   * @return Single which emmit when the operation was finished.
+   */
+  default Single<Void> addAlias(String alias, String index) {
+    return aliases(new JsonArray()
+      .add(new JsonObject()
+        .put("add", new JsonObject().put("index", index).put("alias", alias))
+      )
+    );
+  }
+
+  /**
+   * Remove an existing alias from an index.
+   * @param alias Alias name.
+   * @param index Index name.
+   * @return Single which emmit when the operation was finished.
+   */
+  default Single<Void> removeAlias(String alias, String index) {
+    return aliases(new JsonArray()
+      .add(new JsonObject()
+        .put("remove", new JsonObject().put("index", index).put("alias", alias))
+      )
+    );
+  }
+
+  /**
+   * Elasticsearch aliases api to create or remove aliases.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
+   *
+   * @param actions Add or remove actions.
+   * @return Single that emmit if the reindex process started.
+   */
+  Single<Void> aliases(JsonArray actions);
+
+  /**
+   * @return All aliases of all elasticsearch indices.
+   */
+  Single<JsonObject> getAliases();
+
+  /**
+   * Elasticsearch reindex api to fast copy a index into an another one.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html
+   *
+   * @param src The source index
+   * @param dest The destination index
+   * <p>
+   *  <b>Note:</b> If the index does not exists, it will copy all mappings from the old one.
+   * </p>
+   * @return Single that emmit if the reindex process started.
+   */
+  default Single<Void> reindex(JsonObject src, JsonObject dest) {
+    return reindex(src, dest, null);
+  }
+
+  /**
+   * Elasticsearch reindex api to fast copy a index into an another one.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html
+   *
+   * @param src The source index
+   * @param dest The destination index
+   * <p>
+   *  <b>Note:</b> If the index does not exists, it will copy all mappings from the old one.
+   * </p>
+   * @param script Es scripts like painless to map and modify the copied data. (May be <code>null</code>)
+   * @return Single which emmit if the reindex process started.
+   */
+  Single<Void> reindex(JsonObject src, JsonObject dest, JsonObject script);
+
+  /**
+   * Delete the whole index.
+   * @return Single that emit when the index has been deleted.
+   */
+  Single<Void> delete();
+
+  /**
+   * @return All indices names as a list.
+   */
+  Single<List<String>> indices();
 
   /**
    * Check if the given bulk response contains errors

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchInstaller.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchInstaller.java
@@ -29,7 +29,6 @@ import io.vertx.rxjava.core.file.AsyncFile;
 import io.vertx.rxjava.core.file.FileSystem;
 import io.vertx.rxjava.core.http.HttpClient;
 import io.vertx.rxjava.core.http.HttpClientRequest;
-import rx.Observable;
 import rx.Single;
 
 /**
@@ -56,9 +55,9 @@ public class ElasticsearchInstaller {
    * @param downloadUrl the URL to the ZIP file containing Elasticsearch
    * @param destPath the path to the destination folder where the downloaded ZIP
    * file should be extracted to
-   * @return an observable emitting the path to the extracted Elasticsearch
+   * @return an single emitting the path to the extracted Elasticsearch
    */
-  public Observable<String> download(String downloadUrl, String destPath) {
+  public Single<String> download(String downloadUrl, String destPath) {
     return download(downloadUrl, destPath, true);
   }
   
@@ -72,7 +71,7 @@ public class ElasticsearchInstaller {
    * ZIP file should be stripped away.
    * @return a single emitting the path to the extracted Elasticsearch
    */
-  public Observable<String> download(String downloadUrl, String destPath,
+  public Single<String> download(String downloadUrl, String destPath,
       boolean strip) {
     FileSystem fs = vertx.fileSystem();
     return fs.rxExists(destPath)
@@ -81,8 +80,7 @@ public class ElasticsearchInstaller {
             return Single.just(destPath);
           }
           return downloadNoCheck(downloadUrl, destPath, strip);
-        })
-        .toObservable();
+        });
   }
   
   /**

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchRunner.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/ElasticsearchRunner.java
@@ -20,6 +20,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.rxjava.core.Vertx;
 import rx.Observable;
+import rx.Single;
 
 /**
  * Runs an Elasticsearch instance
@@ -45,9 +46,9 @@ public class ElasticsearchRunner {
    * @param host the host Elasticsearch should bind to
    * @param port the port Elasticsearch should listen on
    * @param elasticsearchInstallPath the path where Elasticsearch is installed
-   * @return an observable that emits exactly one item when Elasticsearch has started
+   * @return an single that emits exactly one item when Elasticsearch has started
    */
-  public Observable<Void> runElasticsearch(String host, int port,
+  public Single<Void> runElasticsearch(String host, int port,
       String elasticsearchInstallPath) {
     JsonObject config = vertx.getOrCreateContext().config();
     String storage = config.getString(ConfigConstants.STORAGE_FILE_PATH);
@@ -97,24 +98,24 @@ public class ElasticsearchRunner {
       } catch (IOException e) {
         f.fail(e);
       }
-    }).toObservable();
+    });
   }
   
   /**
    * Wait 60 seconds or until Elasticsearch is up and running, whatever
    * comes first
    * @param client the client to use to check if Elasticsearch is running
-   * @return an observable that emits exactly one item when Elasticsearch
+   * @return an single that emits exactly one item when Elasticsearch
    * is running
    */
-  public Observable<Void> waitUntilElasticsearchRunning(
+  public Single<Void> waitUntilElasticsearchRunning(
       ElasticsearchClient client) {
     final Throwable repeat = new NoStackTraceThrowable("");
-    return Observable.defer(client::isRunning).flatMap(running -> {
+    return Single.defer(client::isRunning).flatMap(running -> {
       if (!running) {
-        return Observable.error(repeat);
+        return Single.error(repeat);
       }
-      return Observable.just(running);
+      return Single.just(running);
     }).retryWhen(errors -> {
       Observable<Throwable> o = errors.flatMap(t -> {
         if (t == repeat) {

--- a/georocket-server/src/main/java/io/georocket/index/elasticsearch/EmbeddedElasticsearchClient.java
+++ b/georocket-server/src/main/java/io/georocket/index/elasticsearch/EmbeddedElasticsearchClient.java
@@ -6,7 +6,7 @@ import org.jooq.lambda.tuple.Tuple2;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import rx.Observable;
+import rx.Single;
 
 /**
  * A client for embedded Elasticsearch instances. Will shut down the embedded
@@ -35,91 +35,116 @@ public class EmbeddedElasticsearchClient implements ElasticsearchClient {
   }
 
   @Override
-  public Observable<JsonObject> bulkInsert(String type,
+  public Single<JsonObject> bulkInsert(String type,
       List<Tuple2<String, JsonObject>> documents) {
     return delegate.bulkInsert(type, documents);
   }
 
   @Override
-  public Observable<JsonObject> beginScroll(String type, JsonObject query,
+  public Single<JsonObject> beginScroll(String type, JsonObject query,
     JsonObject postFilter, JsonObject aggregations, JsonObject parameters, String timeout) {
     return delegate.beginScroll(type, query, postFilter, aggregations, parameters, timeout);
   }
 
   @Override
-  public Observable<JsonObject> continueScroll(String scrollId, String timeout) {
+  public Single<JsonObject> continueScroll(String scrollId, String timeout) {
     return delegate.continueScroll(scrollId, timeout);
   }
 
   @Override
-  public Observable<JsonObject> search(String type, JsonObject query,
+  public Single<JsonObject> search(String type, JsonObject query,
     JsonObject postFilter, JsonObject aggregations, JsonObject parameters) {
     return delegate.search(type, query, postFilter, aggregations, parameters);
   }
 
   @Override
-  public Observable<Long> count(String type, JsonObject query) {
+  public Single<Long> count(String type, JsonObject query) {
     return delegate.count(type, query);
   }
 
   @Override
-  public Observable<JsonObject> updateByQuery(String type, JsonObject postFilter,
+  public Single<JsonObject> updateByQuery(String type, JsonObject postFilter,
       JsonObject script) {
     return delegate.updateByQuery(type, postFilter, script);
   }
 
   @Override
-  public Observable<JsonObject> bulkDelete(String type, JsonArray ids) {
+  public Single<JsonObject> bulkDelete(String type, JsonArray ids) {
     return delegate.bulkDelete(type, ids);
   }
 
   @Override
-  public Observable<Boolean> indexExists() {
+  public Single<Boolean> indexExists() {
     return delegate.indexExists();
   }
 
   @Override
-  public Observable<Boolean> typeExists(String type) {
+  public Single<Boolean> typeExists(String type) {
     return delegate.typeExists(type);
   }
 
   @Override
-  public Observable<Boolean> createIndex() {
+  public Single<Boolean> createIndex() {
     return delegate.createIndex();
   }
 
   @Override
-  public Observable<Boolean> createIndex(JsonObject settings) {
+  public Single<Boolean> createIndex(JsonObject settings) {
     return delegate.createIndex(settings);
   }
 
   @Override
-  public Observable<Void> ensureIndex() {
+  public Single<Void> ensureIndex() {
     return delegate.ensureIndex();
   }
 
   @Override
-  public Observable<Boolean> putMapping(String type, JsonObject mapping) {
+  public Single<Boolean> putMapping(String type, JsonObject mapping) {
     return delegate.putMapping(type, mapping);
   }
 
   @Override
-  public Observable<JsonObject> getMapping(String type) {
+  public Single<JsonObject> getMapping(String type) {
     return delegate.getMapping(type);
   }
 
   @Override
-  public Observable<JsonObject> getMapping(String type, String field) {
+  public Single<JsonObject> getMapping(String type, String field) {
     return delegate.getMapping(type, field);
   }
   
   @Override
-  public Observable<Void> ensureMapping(String type, JsonObject mapping) {
+  public Single<Void> ensureMapping(String type, JsonObject mapping) {
     return delegate.ensureMapping(type, mapping);
   }
 
   @Override
-  public Observable<Boolean> isRunning() {
+  public Single<Boolean> isRunning() {
     return delegate.isRunning();
+  }
+
+  @Override
+  public Single<Void> aliases(JsonArray actions) {
+    return delegate.aliases(actions);
+  }
+
+  @Override
+  public Single<JsonObject> getAliases() {
+    return delegate.getAliases();
+  }
+
+  @Override
+  public Single<Void> reindex(JsonObject src, JsonObject dest, JsonObject script) {
+    return delegate.reindex(src, dest, script);
+  }
+
+  @Override
+  public Single<Void> delete() {
+    return delegate.delete();
+  }
+
+  @Override
+  public Single<List<String>> indices() {
+    return delegate.indices();
   }
 }


### PR DESCRIPTION
* use single when observable emits only one item
* add additional ES API methods
  * reindex: copy all data into another index
  * alias: create and remove aliases
  * delete: delete the whole index
  * indices: list of all indices