### PR TITLE
Paralellize CI Jobs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,7 +6,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
+    strategy:
+      fail-fast: true
+      matrix:
+        server-integration-test-var: [ 'standalone', 'h2', 'mongo', 's3', 'hdfs'] 
+        
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK 1.8
@@ -25,7 +30,7 @@ jobs:
       - name: Run integration tests
         run: |
           cd georocket-server/integration-tests
-          ./test.sh
+          ./test-one.sh ${{ matrix.server-integration-test-var }}
           cd ../..
 
       - name: Upload snapshot


### PR DESCRIPTION
# Parallalized CI Jobs: 

Actions looked like: 
![CI-Jobs_Old](https://user-images.githubusercontent.com/24325735/75551811-483dd600-5a35-11ea-8598-56dd8b441602.PNG)

and will now look like:
![CI-Jobs_New](https://user-images.githubusercontent.com/24325735/75551827-4ffd7a80-5a35-11ea-8347-7b2111d3468c.PNG)

Pretty much tranformed test.sh into github action features with built in parallelization. Performance increase: About half the time needed
Old:
![CI-Jobs_Time_Old](https://user-images.githubusercontent.com/24325735/75552339-62c47f00-5a36-11ea-8627-9ef496890767.PNG)

New:
![CI-Jobs_Time_New](https://user-images.githubusercontent.com/24325735/75552352-6821c980-5a36-11ea-8dac-a5ec1c328f57.PNG)

Edit: Resolved
> I've had problems with a UnitTest: GetPropertyCommandTest.kt in georocket-cli/src/test/kotlin/io/georocket/commands/GetPropertyCommandTest.kt
> 
> which caused to occasionally fail builds. Is there a known issue? 
