### PR TITLE
Feature/ogc api features

### DIFF
--- a/src/main/kotlin/io/georocket/ogcapifeatures/ApiEndpoint.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/ApiEndpoint.kt
@@ -4,6 +4,7 @@ import com.mitchellbosecke.pebble.PebbleEngine
 import com.mitchellbosecke.pebble.loader.ClasspathLoader
 import io.georocket.GeoRocket
 import io.georocket.http.Endpoint
+import io.georocket.ogcapifeatures.views.Views
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.web.Router
@@ -33,7 +34,7 @@ class ApiEndpoint(private val vertx: Vertx) : Endpoint {
     router.get("/").handler { ctx ->
       val response = ctx.response()
       try {
-        response.putHeader("content-type", "application/json")
+        response.putHeader("content-type", Views.ContentTypes.JSON)
 
         val engine = PebbleEngine.Builder()
           .loader(ClasspathLoader(this::class.java.classLoader))

--- a/src/main/kotlin/io/georocket/ogcapifeatures/ConformanceEndpoint.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/ConformanceEndpoint.kt
@@ -18,7 +18,7 @@ class ConformanceEndpoint(private val vertx: Vertx) : Endpoint {
     router.get("/").produces(Views.ContentTypes.JSON).handler() { ctx -> onGet(ctx, JsonViews) }
     router.get("/").produces(Views.ContentTypes.XML).handler() { ctx -> onGet(ctx, XmlViews) }
     router.get("/").handler { context ->
-      respondWithHttp406NotAcceptable(context, listOf(Views.ContentTypes.JSON, Views.ContentTypes.XML))
+      respondWithHttp406NotAcceptable(context.response(), listOf(Views.ContentTypes.JSON, Views.ContentTypes.XML))
     }
     return router
   }

--- a/src/main/kotlin/io/georocket/ogcapifeatures/ConformanceEndpoint.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/ConformanceEndpoint.kt
@@ -15,10 +15,10 @@ import io.vertx.ext.web.RoutingContext
 class ConformanceEndpoint(private val vertx: Vertx) : Endpoint {
   override suspend fun createRouter(): Router {
     val router = Router.router(vertx)
-    router.get("/").produces("application/json").handler() { ctx -> onGet(ctx, JsonViews) }
-    router.get("/").produces("application/xml").handler() { ctx -> onGet(ctx, XmlViews) }
+    router.get("/").produces(Views.ContentTypes.JSON).handler() { ctx -> onGet(ctx, JsonViews) }
+    router.get("/").produces(Views.ContentTypes.XML).handler() { ctx -> onGet(ctx, XmlViews) }
     router.get("/").handler { context ->
-      respondWithHttp406NotAcceptable(context, listOf("application/json", "application/xml"))
+      respondWithHttp406NotAcceptable(context, listOf(Views.ContentTypes.JSON, Views.ContentTypes.XML))
     }
     return router
   }

--- a/src/main/kotlin/io/georocket/ogcapifeatures/LandingPageEndpoint.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/LandingPageEndpoint.kt
@@ -24,10 +24,10 @@ class LandingPageEndpoint(
 
   override suspend fun createRouter(): Router {
     val router = Router.router(vertx)
-    router.get("/").produces("application/json").handler { ctx -> onInfo(ctx, JsonViews) }
-    router.get("/").produces("application/xml").handler { ctx -> onInfo(ctx, XmlViews) }
+    router.get("/").produces(Views.ContentTypes.JSON).handler { ctx -> onInfo(ctx, JsonViews) }
+    router.get("/").produces(Views.ContentTypes.XML).handler { ctx -> onInfo(ctx, XmlViews) }
     router.get("/").handler { context ->
-      respondWithHttp406NotAcceptable(context, listOf("application/json", "application/xml"))
+      respondWithHttp406NotAcceptable(context, listOf(Views.ContentTypes.JSON, Views.ContentTypes.XML))
     }
 
     router.mountSubRouter("/api", ae.createRouter())
@@ -49,25 +49,25 @@ class LandingPageEndpoint(
       Views.Link(
         href = PathUtils.join(basePath, "conformance"),
         rel = "conformance",
-        type = "application/json",
+        type = Views.ContentTypes.JSON,
         title = "Conformance classes implemented by this server as JSON"
       ),
       Views.Link(
         href = PathUtils.join(basePath, "conformance"),
         rel = "conformance",
-        type = "application/xml",
+        type = Views.ContentTypes.XML,
         title = "Conformance classes implemented by this server as XML"
       ),
       Views.Link(
         href = PathUtils.join(basePath, "collections"),
         rel = "data",
-        type = "application/json",
+        type = Views.ContentTypes.JSON,
         title = "Metadata about feature collections as JSON"
       ),
       Views.Link(
         href = PathUtils.join(basePath, "collections"),
         rel = "data",
-        type = "application/xml",
+        type = Views.ContentTypes.XML,
         title = "Metadata about feature collections as XML"
       ),
       Views.Link(

--- a/src/main/kotlin/io/georocket/ogcapifeatures/LandingPageEndpoint.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/LandingPageEndpoint.kt
@@ -27,7 +27,7 @@ class LandingPageEndpoint(
     router.get("/").produces(Views.ContentTypes.JSON).handler { ctx -> onInfo(ctx, JsonViews) }
     router.get("/").produces(Views.ContentTypes.XML).handler { ctx -> onInfo(ctx, XmlViews) }
     router.get("/").handler { context ->
-      respondWithHttp406NotAcceptable(context, listOf(Views.ContentTypes.JSON, Views.ContentTypes.XML))
+      respondWithHttp406NotAcceptable(context.response(), listOf(Views.ContentTypes.JSON, Views.ContentTypes.XML))
     }
 
     router.mountSubRouter("/api", ae.createRouter())

--- a/src/main/kotlin/io/georocket/ogcapifeatures/NotAcceptableResponse.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/NotAcceptableResponse.kt
@@ -1,5 +1,6 @@
 package io.georocket.ogcapifeatures
 
+import io.georocket.ogcapifeatures.views.Views
 import io.vertx.ext.web.RoutingContext
 import io.vertx.kotlin.core.json.jsonObjectOf
 
@@ -10,7 +11,7 @@ fun respondWithHttp406NotAcceptable(context: RoutingContext, accept: List<String
   val response = context.response()
   response.statusCode = 406
   response.statusMessage = "Not Acceptable"
-  response.putHeader("Content-Type", "application/json")
+  response.putHeader("Content-Type", Views.ContentTypes.JSON)
   response.send(jsonObjectOf(
     "accept" to accept
   ).encodePrettily())

--- a/src/main/kotlin/io/georocket/ogcapifeatures/NotAcceptableResponse.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/NotAcceptableResponse.kt
@@ -1,14 +1,14 @@
 package io.georocket.ogcapifeatures
 
 import io.georocket.ogcapifeatures.views.Views
+import io.vertx.core.http.HttpServerResponse
 import io.vertx.ext.web.RoutingContext
 import io.vertx.kotlin.core.json.jsonObjectOf
 
 /**
  * Responds with the 406 "Not Acceptable" status code and lists all acceptable content types in the body.
  */
-fun respondWithHttp406NotAcceptable(context: RoutingContext, accept: List<String>) {
-  val response = context.response()
+fun respondWithHttp406NotAcceptable(response: HttpServerResponse, accept: List<String>) {
   response.statusCode = 406
   response.statusMessage = "Not Acceptable"
   response.putHeader("Content-Type", Views.ContentTypes.JSON)

--- a/src/main/kotlin/io/georocket/ogcapifeatures/views/Views.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/views/Views.kt
@@ -58,6 +58,8 @@ interface Views {
 
   suspend fun items(response: HttpServerResponse, links: List<Link>, numberReturned: Int, chunks: Flow<Pair<Buffer, ChunkMeta>>)
 
+  suspend fun item(response: HttpServerResponse, links: List<Link>, chunk: Buffer, meta: ChunkMeta, id: String)
+
 }
 
 suspend inline fun<reified T: ChunkMeta> mergeChunks(response: HttpServerResponse, merger: Merger<T>, chunks: Flow<Pair<Buffer, ChunkMeta>>, log: Logger) {

--- a/src/main/kotlin/io/georocket/ogcapifeatures/views/Views.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/views/Views.kt
@@ -58,7 +58,7 @@ interface Views {
 
   suspend fun items(response: HttpServerResponse, links: List<Link>, numberReturned: Int, chunks: Flow<Pair<Buffer, ChunkMeta>>)
 
-  suspend fun item(response: HttpServerResponse, links: List<Link>, chunk: Buffer, meta: ChunkMeta, id: String)
+  fun item(response: HttpServerResponse, links: List<Link>, item: Buffer)
 
 }
 

--- a/src/main/kotlin/io/georocket/ogcapifeatures/views/Views.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/views/Views.kt
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 import io.georocket.http.Endpoint
 import io.georocket.ogcapifeatures.views.xml.XML_NAMESPACE_ATOM
 import io.georocket.ogcapifeatures.views.xml.XML_NAMESPACE_CORE
-import io.georocket.ogcapifeatures.views.xml.XmlViews
 import io.georocket.output.Merger
 import io.georocket.storage.ChunkMeta
-import io.georocket.storage.XMLChunkMeta
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpServerResponse
 import kotlinx.coroutines.flow.Flow
@@ -41,6 +39,14 @@ interface Views {
     @JacksonXmlProperty(localName = "Link", namespace = XML_NAMESPACE_ATOM)
     val links: List<Link>,
   )
+
+  object ContentTypes {
+    const val JSON = "application/json"
+    const val GEO_JSON = "application/geo+json"
+    const val XML = "application/xml"
+    const val GML_XML = "application/gml+xml"
+    const val GML_SF2_XML = "application/gml+xml; version=3.2; profile=http://www.opengis.net/def/profile/ogc/2.0/gml-sf2"  // GML profile simple features level 2
+  }
 
   fun landingPage(response: HttpServerResponse, links: List<Link>)
 

--- a/src/main/kotlin/io/georocket/ogcapifeatures/views/json/JsonViews.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/views/json/JsonViews.kt
@@ -1,12 +1,9 @@
 package io.georocket.ogcapifeatures.views.json
 
-import io.georocket.http.Endpoint
 import io.georocket.ogcapifeatures.views.Views
 import io.georocket.ogcapifeatures.views.mergeChunks
-import io.georocket.ogcapifeatures.views.xml.XmlViews
 import io.georocket.output.geojson.GeoJsonMerger
 import io.georocket.storage.ChunkMeta
-import io.georocket.storage.GeoJsonChunkMeta
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpServerResponse
 import io.vertx.core.json.JsonObject
@@ -18,7 +15,7 @@ object JsonViews: Views {
 
   private val log = LoggerFactory.getLogger(JsonViews::class.java)
 
-  fun linkToJson(link: Views.Link): JsonObject {
+  private fun linkToJson(link: Views.Link): JsonObject {
     val json = JsonObject()
     json.put("href", link.href)
     if (link.rel != null) {
@@ -48,7 +45,7 @@ object JsonViews: Views {
       "description" to "Welcome to the GeoRocket OGC API Features",
       "links" to links.map(this::linkToJson)
     )
-    response.putHeader("Content-Type", "application/json")
+    response.putHeader("Content-Type", Views.ContentTypes.JSON)
     response.end(o.encodePrettily())
   }
 
@@ -56,7 +53,7 @@ object JsonViews: Views {
     val o = jsonObjectOf(
       "conformsTo" to conformsTo
     ).encodePrettily()
-    response.putHeader("content-type", "application/json")
+    response.putHeader("content-type", Views.ContentTypes.JSON)
     response.end(o)
   }
 
@@ -67,7 +64,7 @@ object JsonViews: Views {
       "links" to links.map(this::linkToJson),
       "collections" to collections.map(this::collectionToJson)
     ).encodePrettily()
-    response.putHeader("content-type", "application/json")
+    response.putHeader("content-type", Views.ContentTypes.JSON)
     response.end(o)
   }
 
@@ -76,7 +73,7 @@ object JsonViews: Views {
       collection.copy(links = links + collection.links)
     ).encodePrettily()
 
-    response.putHeader("content-type", "application/json")
+    response.putHeader("content-type", Views.ContentTypes.JSON)
     response.end(o)
   }
 
@@ -99,7 +96,7 @@ object JsonViews: Views {
     val merger = GeoJsonMerger(true, extensionProps)
 
     // response headers
-    response.putHeader("content-type", "application/geo+json")
+    response.putHeader("content-type", Views.ContentTypes.GEO_JSON)
     response.isChunked = true
 
     // response body

--- a/src/main/kotlin/io/georocket/ogcapifeatures/views/xml/XmlViews.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/views/xml/XmlViews.kt
@@ -70,7 +70,7 @@ object XmlViews: Views {
   }
 
   override fun landingPage(response: HttpServerResponse, links: List<Views.Link>) {
-    response.putHeader("Content-Type", "application/xml")
+    response.putHeader("Content-Type", Views.ContentTypes.XML)
     addLinkHeaders(response, links)
     response.send(objectMapper.writeValueAsString(LandingPage(
       title = "GeoRocket OGC API Features",
@@ -80,7 +80,7 @@ object XmlViews: Views {
   }
 
   override fun conformance(response: HttpServerResponse, conformsTo: List<String>) {
-    response.putHeader("content-type", "application/xml")
+    response.putHeader("content-type", Views.ContentTypes.XML)
     response.end(objectMapper.writeValueAsString(ConformsTo(
       title = "Conformances",
       description = "List of conformance classes that this API implements.",
@@ -89,7 +89,7 @@ object XmlViews: Views {
   }
 
   override fun collections(response: HttpServerResponse, links: List<Views.Link>, collections: List<Views.Collection>) {
-    response.putHeader("content-type", "application/xml")
+    response.putHeader("content-type", Views.ContentTypes.XML)
     addLinkHeaders(response, links + collections.flatMap { it.links })
     response.end(objectMapper.writeValueAsString(Collections(
       title = "Collections",
@@ -100,7 +100,7 @@ object XmlViews: Views {
   }
 
   override fun collection(response: HttpServerResponse, links: List<Views.Link>, collection: Views.Collection) {
-    response.putHeader("content-type", "application/xml")
+    response.putHeader("content-type", Views.ContentTypes.XML)
     addLinkHeaders(response, links + collection.links)
     response.end(objectMapper.writeValueAsString(
       Collections(
@@ -121,10 +121,7 @@ object XmlViews: Views {
     // headers
     addLinkHeaders(response, links)
     response.putHeader("OGC-NumberReturned", numberReturned.toString())
-    response.putHeader(
-      "content-type",
-      "application/gml+xml; version=3.2; profile=http://www.opengis.net/def/profile/ogc/2.0/gml-sf2"
-    )
+    response.putHeader("content-type", Views.ContentTypes.GML_SF2_XML)
     response.isChunked = true
 
     // body is the merged xml

--- a/src/main/kotlin/io/georocket/output/xml/XMLMerger.kt
+++ b/src/main/kotlin/io/georocket/output/xml/XMLMerger.kt
@@ -53,7 +53,7 @@ class XMLMerger(private val optimistic: Boolean) : Merger<XMLChunkMeta> {
 
     // current strategy is able to handle the chunk
     initialized = true
-    return strategy.init(chunkMetadata)
+    strategy.init(chunkMetadata)
   }
 
   override suspend fun merge(chunk: Buffer, chunkMetadata: XMLChunkMeta,

--- a/src/main/resources/io/georocket/ogcapifeatures/api.yaml
+++ b/src/main/resources/io/georocket/ogcapifeatures/api.yaml
@@ -113,6 +113,7 @@ paths:
       - $ref: '#/components/parameters/limit'
       - $ref: '#/components/parameters/bbox'
       - $ref: '#/components/parameters/datetime'
+      - $ref: '#/components/parameters/freeform'
       responses:
         '200':
           description: >-
@@ -164,6 +165,13 @@ paths:
                 type: string
 components:
   parameters:
+    freeform:
+      name: queryField
+      in: query
+      schema:
+        type: object
+        additionalProperties: true
+      style: form
     limit:
       name: limit
       in: query

--- a/src/main/resources/io/georocket/ogcapifeatures/api.yaml
+++ b/src/main/resources/io/georocket/ogcapifeatures/api.yaml
@@ -2,8 +2,10 @@ openapi: 3.0.1
 info:
   title: GeoRocket - OGC API Features
   version: {{ version }}
+servers:
+  - url: {{ path }}
 paths:
-  '{{ path }}/':
+  '/':
     get:
       summary: landing page of this API
       description: >-
@@ -22,7 +24,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '{{ path }}/conformance':
+  '/conformance':
     get:
       summary: information about standards that this API conforms to
       description: >-
@@ -44,7 +46,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/exception'
-  '{{ path }}/collections':
+  '/collections':
     get:
       summary: describe the feature collections in the dataset
       operationId: describeCollections
@@ -69,7 +71,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '{{ path }}/collections/{collectionId}':
+  '/collections/{collectionId}':
     get:
       summary: 'describe the {collectionId} feature collection'
       operationId: describeCollection
@@ -96,7 +98,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '{{ path }}/collections/{collectionId}/items':
+  '/collections/{collectionId}/items':
     get:
       summary: 'retrieve features of feature collection {collectionId}'
       description: >-
@@ -110,7 +112,7 @@ paths:
       - $ref: '#/components/parameters/collectionId'
       - $ref: '#/components/parameters/limit'
       - $ref: '#/components/parameters/bbox'
-      - $ref: '#/components/parameters/time'
+      - $ref: '#/components/parameters/datetime'
       responses:
         '200':
           description: >-
@@ -132,7 +134,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '{{ path }}/collections/{collectionId}/items/{featureId}':
+  '/collections/{collectionId}/items/{featureId}':
     get:
       summary: retrieve a feature
       operationId: getFeature
@@ -220,8 +222,8 @@ components:
           type: number
       style: form
       explode: false
-    time:
-      name: time
+    datetime:
+      name: datetime
       in: query
       description: >-
         Either a date-time or a period string that adheres to RFC 3339. Examples:


### PR DESCRIPTION
 - Items endpoint
 - (Single) feature endpoint
 - Add ids to all features, so that every feature can be accessed in the Feature endpoint.
   Features that do not have an ID get assigned an "artificial id" value, that encodes the path of the chunk. (with some extra encoding because of a bug in the OGC-Api-Views Conformance Test Suite... see corresponding comment in code...)