### PR TITLE
Query Perf

### DIFF
--- a/src/main/kotlin/io/georocket/cli/SearchCommand.kt
+++ b/src/main/kotlin/io/georocket/cli/SearchCommand.kt
@@ -78,10 +78,10 @@ class SearchCommand : DataCommand() {
       var accepted = 0L
       var notaccepted = 0L
       val metas = index.getMeta(query)
-      metas.collect { chunkMeta ->
-        val chunk = store.getOne(chunkMeta.first)
+      val chunks = store.getManyParallelBatched(metas)
+      chunks.collect { (chunk, meta) ->
         try {
-          merger.merge(chunk, chunkMeta.second, out)
+          merger.merge(chunk, meta, out)
           accepted++
         } catch (e: IllegalStateException) {
           // Chunk cannot be merged. maybe it's a new one that has

--- a/src/main/kotlin/io/georocket/index/postgresql/PostgreSQLQueryTranslator.kt
+++ b/src/main/kotlin/io/georocket/index/postgresql/PostgreSQLQueryTranslator.kt
@@ -138,9 +138,8 @@ object PostgreSQLQueryTranslator {
       }
 
       is StartsWith -> {
-        result.append("(")
         appendField(jsonField, query.field, result)
-        result.append(")::text LIKE ")
+        result.append("#>> '{}' LIKE ")
         appendParam(escapeLikeExpression(query.prefix) + "%", result, params)
       }
     }

--- a/src/main/kotlin/io/georocket/ogcapifeatures/CollectionsEndpoint.kt
+++ b/src/main/kotlin/io/georocket/ogcapifeatures/CollectionsEndpoint.kt
@@ -658,8 +658,10 @@ class CollectionsEndpoint(
       } else {
         null
       }
-      val chunks = result.items.asFlow().map { (path, meta) ->
-        val chunk = store.getOne(path)
+      val chunks = store.getManyParallelBatched(result.items.asFlow()
+        .map{(path, meta) -> path to (path to meta)}
+      ).map { (chunk, pathMeta) ->
+        val (path, meta) = pathMeta
         val chunkWithIds = insertArtificialIds(chunk, meta, path)
         chunkWithIds to meta
       }

--- a/src/main/kotlin/io/georocket/storage/Store.kt
+++ b/src/main/kotlin/io/georocket/storage/Store.kt
@@ -2,7 +2,10 @@ package io.georocket.storage
 
 import io.georocket.util.PathUtils
 import io.georocket.util.UniqueID
+import io.georocket.util.chunked
 import io.vertx.core.buffer.Buffer
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 
 /**
  * A store for chunks
@@ -37,6 +40,47 @@ interface Store {
    * Get a chunk with a given [path] from the store
    */
   suspend fun getOne(path: String): Buffer
+
+  /**
+   * Get chunks with the given [paths].
+   * Implementors might use bulk operations to make [getMany] more efficient than multiple calls to [getOne].
+   */
+  suspend fun getMany(paths: List<String>): Map<String, Buffer> {
+    // default implementation: Call getOne for each requested chunk
+    return paths.associateWith { path ->
+      getOne(path)
+    }
+  }
+
+  /**
+   * Get chunks with the given [paths].
+   * This will fetch chunks in batches of size [maxChunksPerBatch] (see [getMany]). Up to [maxConcurrentBatches]
+   * batches will be processed in parallel.
+   */
+  suspend fun<T> getManyParallelBatched(
+    paths: Flow<Pair<String, T>>,
+    maxChunksPerBatch: Int = 100,
+    maxConcurrentBatches: Int = 20
+  ): Flow<Pair<Buffer, T>> {
+
+    // Scope is valid until the stream has been fully collected.
+    val scope = CoroutineScope(Dispatchers.Default)
+
+    return paths
+      .chunked(maxChunksPerBatch)
+      .map { batch ->
+        scope.async {
+          val results = getMany(batch.map { it.first })
+          batch.map { (filename, t) ->
+            val buf = results[filename] ?: throw NoSuchElementException("Could not find chunk with path `$filename'")
+            buf to t
+          }
+        }
+      }
+      .buffer(capacity = maxConcurrentBatches)
+      .transform { it.await().forEach { result -> emit(result) } }
+      .onCompletion { scope.cancel() }
+  }
 
   /**
    * Delete all chunks from the store that match a given [paths]. Return

--- a/src/main/kotlin/io/georocket/util/Chunked.kt
+++ b/src/main/kotlin/io/georocket/util/Chunked.kt
@@ -2,6 +2,7 @@ package io.georocket.util
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
 
 suspend fun <T> Flow<T>.collectChunked(chunkSize: Int, collector: FlowCollector<Collection<T>>) {
   val chunk = mutableListOf<T>()
@@ -14,5 +15,21 @@ suspend fun <T> Flow<T>.collectChunked(chunkSize: Int, collector: FlowCollector<
   }
   if (chunk.isNotEmpty()) {
     collector.emit(chunk)
+  }
+}
+
+suspend fun <T> Flow<T>.chunked(chunkSize: Int): Flow<List<T>> {
+  return flow {
+    var chunk = mutableListOf<T>()
+    collect { element ->
+      chunk.add(element)
+      if (chunk.size >= chunkSize) {
+        emit(chunk)
+        chunk = mutableListOf()
+      }
+    }
+    if (chunk.isNotEmpty()) {
+      emit(chunk)
+    }
   }
 }

--- a/src/test/kotlin/io/georocket/storage/StorageTest.kt
+++ b/src/test/kotlin/io/georocket/storage/StorageTest.kt
@@ -149,6 +149,35 @@ abstract class StorageTest {
     }
   }
 
+  @Test
+  fun testGetMany(ctx: VertxTestContext, vertx: Vertx) {
+    CoroutineScope(vertx.dispatcher()).launch {
+      val store = createStore(vertx)
+
+      // prepareData only adds a single file.
+      // Add a few more, so we can test getMany with many files.
+      store.addMany(listOf(
+        Buffer.buffer("file 1") to "a",
+        Buffer.buffer("file 2") to "b",
+        Buffer.buffer("file 3") to "c",
+        Buffer.buffer("file 4") to "d",
+        Buffer.buffer("file 5") to "e",
+      ))
+
+      // test by getting 3 files in bulk
+      val result = store.getMany(listOf("a", "c", "e"))
+      ctx.verify {
+        assertThat(result).isEqualTo(mapOf(
+          "a" to Buffer.buffer("file 1"),
+          "c" to Buffer.buffer("file 3"),
+          "e" to Buffer.buffer("file 5"),
+        ))
+      }
+
+      ctx.completeNow()
+    }
+  }
+
   /**
    * Add test data and compare the data with the stored one
    */

--- a/src/test/resources/io/georocket/query/fixtures/string_with_path.json
+++ b/src/test/resources/io/georocket/query/fixtures/string_with_path.json
@@ -15,7 +15,7 @@
     }]
   },
   "expectedPg": {
-    "where": "((data->'tags' ? $1 OR data->'props' @> $2) AND (data->'layer')::text LIKE $3)",
+    "where": "((data->'tags' ? $1 OR data->'props' @> $2) AND data->'layer'#>> '{}' LIKE $3)",
     "params": ["bla", [{"value": "bla"}], "mypath/%"]
   }
 }


### PR DESCRIPTION
 - Add "getMany" method in Store, to retrieve multiple chunks in a bulk operation. 
 - When querying, chunks are loaded in bulk (new getMany method) and in parallel. Query performance improved approximately by factor 10 for the mongodb and postgres storage backends.
 - Small bugfix for "StartsWith"-Queries with postgres Index