### PR TITLE
Create database indexes for efficient query execution

### DIFF
--- a/conf/georocket.yaml
+++ b/conf/georocket.yaml
@@ -86,6 +86,18 @@ georocket:
     # import as soon as at least half of the queued chunks have been indexed.
     maxQueuedChunks: 10000
 
+    # Properties and/or attributes, for which to add database indexes in addition to the generic database indexes that
+    # are always created. This allows efficient range queries for the listed fields with the postgres driver.
+    #
+    # For example, the query 'LTE(scalerank 2)' would benefit from declaring 'scalerank' as an indexed field.
+    # It is not necessary to include fields that are only ever used with equality conditions. For example, a field
+    # such as 'country_code' would only make sense to be used like 'EQ(country_code de)' but not  as a
+    # range query (LT, LTE, GT, GTE operators).
+    # Also, the mongodb driver currently does not use the indexed fields, so indexedFields can be left empty
+    # when using mongodb.
+    indexedFields:
+      - scalerank
+
     # After chunks have been imported into the store and before they are
     # indexed, they are temporarily put into a cache to save bandwidth and time.
     indexableChunkCache:

--- a/src/main/kotlin/io/georocket/cli/ServerCommand.kt
+++ b/src/main/kotlin/io/georocket/cli/ServerCommand.kt
@@ -22,9 +22,10 @@ class ServerCommand : GeoRocketCommand() {
   override val usageName = "server"
   override val usageDescription = "Run GeoRocket in server mode"
 
-  override suspend fun doRun(remainingArgs: Array<String>, reader: InputReader,
-      out: WriteStream<Buffer>): Int {
-    // print banner
+  override suspend fun doRun(
+    remainingArgs: Array<String>, reader: InputReader,
+    out: WriteStream<Buffer>
+  ): Int {
     val banner = GeoRocket::class.java.getResource("georocket_banner.txt")!!.readText()
     println(banner)
 
@@ -32,8 +33,10 @@ class ServerCommand : GeoRocketCommand() {
     val memoryMXBean = ManagementFactory.getMemoryMXBean()
     val memoryInit = memoryMXBean.heapMemoryUsage.init
     val memoryMax = memoryMXBean.heapMemoryUsage.max
-    log.info("Initial heap size: ${SizeFormat.format(memoryInit)}, " +
-        "max heap size: ${SizeFormat.format(memoryMax)}")
+    log.info(
+      "Initial heap size: ${SizeFormat.format(memoryInit)}, " +
+        "max heap size: ${SizeFormat.format(memoryMax)}"
+    )
 
     // deploy main verticle
     val shutdownPromise = Promise.promise<Unit>()

--- a/src/main/kotlin/io/georocket/constants/ConfigConstants.kt
+++ b/src/main/kotlin/io/georocket/constants/ConfigConstants.kt
@@ -43,6 +43,7 @@ object ConfigConstants {
   const val STORAGE_S3_BUCKET = "georocket.storage.s3.bucket"
   const val STORAGE_S3_PATH_STYLE_ACCESS = "georocket.storage.s3.pathStyleAccess"
   const val INDEX_DRIVER = "georocket.index.driver"
+  const val INDEX_INDEXED_FIELDS = "georocket.index.indexedFields"
   const val INDEX_MAX_BULK_SIZE = "georocket.index.maxBulkSize"
   const val INDEX_MONGODB_CONNECTION_STRING = "georocket.index.mongodb.connectionString"
   const val INDEX_POSTGRESQL_URL = "georocket.index.postgresql.url"

--- a/src/main/kotlin/io/georocket/index/DatabaseIndex.kt
+++ b/src/main/kotlin/io/georocket/index/DatabaseIndex.kt
@@ -1,0 +1,64 @@
+package io.georocket.index
+
+import io.georocket.query.QueryPart.ComparisonOperator.EQ
+
+/**
+ * @author Tobias Dorra
+ */
+sealed interface DatabaseIndex {
+
+  val name: String
+
+  /**
+   * Index for scalar values.
+   * Can be used for accelerating [io.georocket.query.Compare] queries with [EQ] comparisons. (No range queries)
+   */
+  data class Eq(val field: String, override val name: String) : DatabaseIndex
+
+  /**
+   * Index for scalar values, with the addition of range queries compared to [DatabaseIndex.Eq].
+   * Can be used for accelerating arbitrary [io.georocket.query.Compare] queries.
+   */
+  data class Range(val field: String, override val name: String) : DatabaseIndex
+
+  /**
+   * Index for string values.
+   * Can be used for accelerating [io.georocket.query.StartsWith].
+   */
+  data class StartsWith(val field: String, override val name: String) : DatabaseIndex
+
+  /**
+   * Index for array values (that contain scalar values).
+   * Can be used for accelerating [io.georocket.query.Contains] queries.
+   */
+  data class Array(val field: String, override val name: String) : DatabaseIndex
+
+  /**
+   * Index for arrays of nested objects.
+   *
+   * MongoDb:
+   * Can be used for accelerating both [io.georocket.query.ElemMatchExists] and
+   * [io.georocket.query.ElemMatchCompare] queries.
+   * However, the order of the [matchedOn] fields matters:
+   * The index can only accelerate queries, that use a prefix of the list of [matchedOn] fields.
+   *
+   * Postgres:
+   * Can only be used for accelerating [io.georocket.query.ElemMatchExists].
+   * For [io.georocket.query.ElemMatchCompare], an [ElemMatchCompare] index is needed.
+   */
+  data class ElemMatchExists(val field: String, val matchedOn: List<String>, override val name: String) : DatabaseIndex
+
+  data class ElemMatchCompare(
+    val field: String,
+    val elemKeyField: String,
+    val elemValueField: String,
+    val keyValue: String,
+    override val name: String
+  ) : DatabaseIndex
+
+  /**
+   * Spatial index for accelerating [io.georocket.query.GeoIntersects] queries.
+   */
+  data class Geo(val field: String, override val name: String) : DatabaseIndex
+
+}

--- a/src/main/kotlin/io/georocket/index/Index.kt
+++ b/src/main/kotlin/io/georocket/index/Index.kt
@@ -1,13 +1,9 @@
 package io.georocket.index
 
-import io.georocket.query.DefaultQueryCompiler
 import io.georocket.query.IndexQuery
 import io.georocket.storage.ChunkMeta
 import io.vertx.core.json.JsonObject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.singleOrNull
 
 interface Index {
   data class AddManyParam(val path: String, val doc: JsonObject, val meta: ChunkMeta)
@@ -21,8 +17,10 @@ interface Index {
 
   suspend fun getMeta(query: IndexQuery): Flow<Pair<String, ChunkMeta>>
 
-  suspend fun getPaginatedMeta(query: IndexQuery, maxPageSize: Int,
-    previousScrollId: String?): Page<Pair<String, ChunkMeta>>
+  suspend fun getPaginatedMeta(
+    query: IndexQuery, maxPageSize: Int,
+    previousScrollId: String?
+  ): Page<Pair<String, ChunkMeta>>
 
   suspend fun getPaths(query: IndexQuery): Flow<String>
 
@@ -45,5 +43,7 @@ interface Index {
   suspend fun getLayers(): Flow<String>
 
   suspend fun existsLayer(name: String): Boolean
+
+  suspend fun setUpDatabaseIndexes(indexes: List<DatabaseIndex>)
 
 }

--- a/src/main/kotlin/io/georocket/index/IndexFactory.kt
+++ b/src/main/kotlin/io/georocket/index/IndexFactory.kt
@@ -25,10 +25,16 @@ object IndexFactory {
     val driver = config.getString(ConfigConstants.INDEX_DRIVER, DRIVER_MONGODB)
 
     log.info("Using database driver: $driver")
-    return when (driver) {
+    val index = when (driver) {
       DRIVER_MONGODB -> MongoDBIndex.create(vertx)
       DRIVER_POSTGRESQL -> PostgreSQLIndex.create(vertx)
       else -> throw IllegalStateException("Unknown database driver `$driver'")
     }
+
+    val indexedFields = config.getJsonArray(ConfigConstants.INDEX_INDEXED_FIELDS).map { it.toString() }
+    val databaseIndexes = (MetaIndexerFactory.ALL + IndexerFactory.ALL)
+      .flatMap { it.getDatabaseIndexes(indexedFields) }
+    index.setUpDatabaseIndexes(databaseIndexes)
+    return index
   }
 }

--- a/src/main/kotlin/io/georocket/index/IndexFactory.kt
+++ b/src/main/kotlin/io/georocket/index/IndexFactory.kt
@@ -31,7 +31,7 @@ object IndexFactory {
       else -> throw IllegalStateException("Unknown database driver `$driver'")
     }
 
-    val indexedFields = config.getJsonArray(ConfigConstants.INDEX_INDEXED_FIELDS).map { it.toString() }
+    val indexedFields = config.getJsonArray(ConfigConstants.INDEX_INDEXED_FIELDS)?.map { it.toString() } ?: emptyList()
     val databaseIndexes = (MetaIndexerFactory.ALL + IndexerFactory.ALL)
       .flatMap { it.getDatabaseIndexes(indexedFields) }
     index.setUpDatabaseIndexes(databaseIndexes)

--- a/src/main/kotlin/io/georocket/index/generic/BoundingBoxIndexerFactory.kt
+++ b/src/main/kotlin/io/georocket/index/generic/BoundingBoxIndexerFactory.kt
@@ -1,6 +1,7 @@
 package io.georocket.index.generic
 
 import io.georocket.constants.ConfigConstants
+import io.georocket.index.DatabaseIndex
 import io.georocket.index.Indexer
 import io.georocket.index.IndexerFactory
 import io.georocket.index.geojson.GeoJsonBoundingBoxIndexer
@@ -29,7 +30,7 @@ class BoundingBoxIndexerFactory : IndexerFactory {
     private const val COMMA_REGEX = "\\s*,\\s*"
     private const val CODE_PREFIX = "([a-zA-Z]+:\\d+:)?"
     private val BBOX_REGEX = (CODE_PREFIX + FLOAT_REGEX + COMMA_REGEX +
-        FLOAT_REGEX + COMMA_REGEX + FLOAT_REGEX + COMMA_REGEX + FLOAT_REGEX).toRegex()
+      FLOAT_REGEX + COMMA_REGEX + FLOAT_REGEX + COMMA_REGEX + FLOAT_REGEX).toRegex()
   }
 
   val defaultCrs: String?
@@ -103,17 +104,23 @@ class BoundingBoxIndexerFactory : IndexerFactory {
     val maxX = points[2]
     val maxY = points[3]
 
-    return GeoIntersects("bbox", jsonObjectOf(
-      "type" to "Polygon",
-      "coordinates" to jsonArrayOf(
-        jsonArrayOf(
-          jsonArrayOf(minX, minY),
-          jsonArrayOf(maxX, minY),
-          jsonArrayOf(maxX, maxY),
-          jsonArrayOf(minX, maxY),
-          jsonArrayOf(minX, minY)
+    return GeoIntersects(
+      "bbox", jsonObjectOf(
+        "type" to "Polygon",
+        "coordinates" to jsonArrayOf(
+          jsonArrayOf(
+            jsonArrayOf(minX, minY),
+            jsonArrayOf(maxX, minY),
+            jsonArrayOf(maxX, maxY),
+            jsonArrayOf(minX, maxY),
+            jsonArrayOf(minX, minY)
+          )
         )
       )
-    ))
+    )
   }
+
+  override fun getDatabaseIndexes(indexedFields: List<String>): List<DatabaseIndex> = listOf(
+    DatabaseIndex.Geo("bbox", "bbox_geo")
+  )
 }

--- a/src/main/kotlin/io/georocket/index/generic/GenericAttributeIndexerFactory.kt
+++ b/src/main/kotlin/io/georocket/index/generic/GenericAttributeIndexerFactory.kt
@@ -1,18 +1,13 @@
 package io.georocket.index.generic
 
+import io.georocket.index.DatabaseIndex
 import io.georocket.index.Indexer
 import io.georocket.index.IndexerFactory
 import io.georocket.index.geojson.GeoJsonGenericAttributeIndexer
 import io.georocket.index.xml.XMLGenericAttributeIndexer
-import io.georocket.query.Compare
-import io.georocket.query.DoubleQueryPart
-import io.georocket.query.ElemMatch
-import io.georocket.query.IndexQuery
-import io.georocket.query.LongQueryPart
+import io.georocket.query.*
 import io.georocket.query.QueryCompiler.MatchPriority
-import io.georocket.query.QueryPart
 import io.georocket.query.QueryPart.ComparisonOperator.EQ
-import io.georocket.query.StringQueryPart
 import io.georocket.util.JsonStreamEvent
 import io.georocket.util.StreamEvent
 import io.georocket.util.XMLStreamEvent
@@ -44,16 +39,31 @@ class GenericAttributeIndexerFactory : IndexerFactory {
       is StringQueryPart, is LongQueryPart, is DoubleQueryPart -> {
         val key = queryPart.key
         if (key != null) {
-          ElemMatch("genAttrs",
-            Compare("key", key, EQ),
+          ElemMatchCompare(
+            "genAttrs",
+            "key" to key,
             Compare("value", queryPart.value, queryPart.comparisonOperator ?: EQ)
           )
         } else {
-          ElemMatch("genAttrs",
-            Compare("value", queryPart.value, EQ)
+          ElemMatchExists(
+            "genAttrs",
+            "value" to queryPart.value
           )
         }
       }
     }
   }
+
+  override fun getDatabaseIndexes(indexedFields: List<String>): List<DatabaseIndex> = listOf(
+    DatabaseIndex.ElemMatchExists("genAttrs", listOf("value", "key"), "gen_attrs_elem_match_exists"),
+    *indexedFields.map { fieldName ->
+      DatabaseIndex.ElemMatchCompare(
+        "genAttrs",
+        "key",
+        "value",
+        fieldName,
+        "gen_attrs_${fieldName}_elem_match_cmp"
+      )
+    }.toTypedArray(),
+  )
 }

--- a/src/main/kotlin/io/georocket/index/geojson/GeoJsonIdIndexerFactory.kt
+++ b/src/main/kotlin/io/georocket/index/geojson/GeoJsonIdIndexerFactory.kt
@@ -1,5 +1,6 @@
 package io.georocket.index.geojson
 
+import io.georocket.index.DatabaseIndex
 import io.georocket.index.Indexer
 import io.georocket.index.IndexerFactory
 import io.georocket.query.Contains
@@ -12,10 +13,10 @@ import io.georocket.util.StreamEvent
 /**
  * @author Tobias Dorra
  */
-class GeoJsonIdIndexerFactory: IndexerFactory {
+class GeoJsonIdIndexerFactory : IndexerFactory {
   companion object {
-    const val GEOJSON_FEATURE_ID = "geoJsonFeatureId"
     const val GEOJSON_FEATURE_IDS = "geoJsonFeatureIds"
+    val validFieldNames = setOf("id", "geoJsonFeatureId")
   }
 
   override fun <T : StreamEvent> createIndexer(eventType: Class<T>): Indexer<T>? {
@@ -26,10 +27,10 @@ class GeoJsonIdIndexerFactory: IndexerFactory {
     return null
   }
 
-  private fun getIdFromQuery(queryPart: QueryPart): String?  {
+  private fun getIdFromQuery(queryPart: QueryPart): String? {
     return if (queryPart.key == null) {
       queryPart.value.toString()
-    } else if (queryPart.comparisonOperator == QueryPart.ComparisonOperator.EQ && queryPart.key == GEOJSON_FEATURE_ID) {
+    } else if (queryPart.comparisonOperator == QueryPart.ComparisonOperator.EQ && validFieldNames.contains(queryPart.key)) {
       queryPart.value.toString()
     } else {
       null
@@ -53,4 +54,8 @@ class GeoJsonIdIndexerFactory: IndexerFactory {
       null
     }
   }
+
+  override fun getDatabaseIndexes(indexedFields: List<String>): List<DatabaseIndex> = listOf(
+    DatabaseIndex.Array(GEOJSON_FEATURE_IDS, "geo_json_feature_ids_array")
+  )
 }

--- a/src/main/kotlin/io/georocket/index/mongodb/MongoDBIndex.kt
+++ b/src/main/kotlin/io/georocket/index/mongodb/MongoDBIndex.kt
@@ -11,24 +11,17 @@ import com.mongodb.reactivestreams.client.MongoDatabase
 import io.georocket.constants.ConfigConstants.EMBEDDED_MONGODB_STORAGE_PATH
 import io.georocket.constants.ConfigConstants.INDEX_MONGODB_CONNECTION_STRING
 import io.georocket.index.AbstractIndex
+import io.georocket.index.DatabaseIndex
 import io.georocket.index.Index
 import io.georocket.index.mongodb.MongoDBQueryTranslator.translate
 import io.georocket.index.normalizeLayer
 import io.georocket.query.IndexQuery
 import io.georocket.query.StartsWith
 import io.georocket.storage.ChunkMeta
-import io.georocket.util.UniqueID
-import io.georocket.util.aggregateAwait
-import io.georocket.util.coDistinct
-import io.georocket.util.coFind
-import io.georocket.util.deleteManyAwait
-import io.georocket.util.findOneAndUpdateAwait
-import io.georocket.util.findOneAwait
-import io.georocket.util.getAwait
-import io.georocket.util.insertManyAwait
-import io.georocket.util.updateManyAwait
+import io.georocket.util.*
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
+import io.vertx.ext.mongo.impl.JsonObjectBsonAdapter
 import io.vertx.kotlin.core.json.json
 import io.vertx.kotlin.core.json.jsonArrayOf
 import io.vertx.kotlin.core.json.jsonObjectOf
@@ -38,17 +31,27 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.collect
+import org.bson.BsonDocument
+import org.bson.BsonInvalidOperationException
+import org.slf4j.LoggerFactory
+
 
 class MongoDBIndex private constructor() : Index, AbstractIndex() {
   companion object {
+    private val log = LoggerFactory.getLogger(MongoDBIndex::class.java)
+
     private const val INTERNAL_ID = "_id"
     private const val CHUNK_META = "chunkMeta"
     private const val LAYER = "layer"
     private const val COLL_DOCUMENTS = "documents"
     private const val COLL_CHUNKMETA = "chunkMeta"
+    private const val IDX_PREFIX = "georocket_"
 
-    suspend fun create(vertx: Vertx, connectionString: String? = null,
-        storagePath: String? = null): MongoDBIndex {
+    suspend fun create(
+      vertx: Vertx, connectionString: String? = null,
+      storagePath: String? = null
+    ): MongoDBIndex {
       val r = MongoDBIndex()
       r.start(vertx, connectionString, storagePath)
       return r
@@ -61,17 +64,20 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
   private lateinit var collDocuments: MongoCollection<JsonObject>
   private lateinit var collChunkMeta: MongoCollection<JsonObject>
 
-  private suspend fun start(vertx: Vertx, connectionString: String?,
-      storagePath: String?) {
+  private suspend fun start(
+    vertx: Vertx, connectionString: String?,
+    storagePath: String?
+  ) {
     val config = vertx.orCreateContext.config()
 
-    val actualConnectionString = connectionString ?:
-      config.getString(INDEX_MONGODB_CONNECTION_STRING)
+    val actualConnectionString = connectionString ?: config.getString(INDEX_MONGODB_CONNECTION_STRING)
     if (actualConnectionString == null) {
       val actualStoragePath = storagePath ?: config.getString(
-        EMBEDDED_MONGODB_STORAGE_PATH) ?:
-          throw IllegalStateException("Missing configuration item `" +
-              EMBEDDED_MONGODB_STORAGE_PATH + "'")
+        EMBEDDED_MONGODB_STORAGE_PATH
+      ) ?: throw IllegalStateException(
+        "Missing configuration item `" +
+          EMBEDDED_MONGODB_STORAGE_PATH + "'"
+      )
       client = SharedMongoClient.createEmbedded(vertx, actualStoragePath)
       db = client.getDatabase(SharedMongoClient.DEFAULT_EMBEDDED_DATABASE)
     } else {
@@ -83,12 +89,22 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
     collDocuments = db.getCollection(COLL_DOCUMENTS, JsonObject::class.java)
     collChunkMeta = db.getCollection(COLL_CHUNKMETA, JsonObject::class.java)
 
-    collDocuments.createIndexes(listOf(IndexModel(Indexes.ascending(CHUNK_META),
-      IndexOptions().background(true)),
-    )).awaitFirstOrNull()
-    collChunkMeta.createIndexes(listOf(IndexModel(Indexes.ascending(CHUNK_META),
-      IndexOptions().unique(true).background(true)),
-    )).awaitFirstOrNull()
+    collDocuments.createIndexes(
+      listOf(
+        IndexModel(
+          Indexes.ascending(CHUNK_META),
+          IndexOptions().background(true)
+        ),
+      )
+    ).awaitFirstOrNull()
+    collChunkMeta.createIndexes(
+      listOf(
+        IndexModel(
+          Indexes.ascending(CHUNK_META),
+          IndexOptions().unique(true).background(true)
+        ),
+      )
+    ).awaitFirstOrNull()
   }
 
   override suspend fun close() {
@@ -98,13 +114,15 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
   private suspend fun addOrGetChunkMeta(meta: ChunkMeta): String {
     return addedChunkMetaCache.getAwait(meta) {
       val metaJson = meta.toJsonObject()
-      val result = collChunkMeta.findOneAndUpdateAwait(jsonObjectOf(
-        CHUNK_META to metaJson
-      ), jsonObjectOf(
-        "\$setOnInsert" to jsonObjectOf(
-          INTERNAL_ID to UniqueID.next()
-        )
-      ), true, ReturnDocument.AFTER, jsonObjectOf(INTERNAL_ID to 1))
+      val result = collChunkMeta.findOneAndUpdateAwait(
+        jsonObjectOf(
+          CHUNK_META to metaJson
+        ), jsonObjectOf(
+          "\$setOnInsert" to jsonObjectOf(
+            INTERNAL_ID to UniqueID.next()
+          )
+        ), true, ReturnDocument.AFTER, jsonObjectOf(INTERNAL_ID to 1)
+      )
       result!!.getString(INTERNAL_ID)
     }
   }
@@ -146,17 +164,22 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
     }
   }
 
-  override suspend fun getPaginatedMeta(query: IndexQuery, maxPageSize: Int,
-      previousScrollId: String?): Index.Page<Pair<String, ChunkMeta>> {
+  override suspend fun getPaginatedMeta(
+    query: IndexQuery, maxPageSize: Int,
+    previousScrollId: String?
+  ): Index.Page<Pair<String, ChunkMeta>> {
     val filter = if (previousScrollId != null) {
-      jsonObjectOf("\$and" to jsonArrayOf(
-        jsonObjectOf("_id" to jsonObjectOf("\$gt" to previousScrollId)),
-        translate(query)
-      ))
+      jsonObjectOf(
+        "\$and" to jsonArrayOf(
+          jsonObjectOf("_id" to jsonObjectOf("\$gt" to previousScrollId)),
+          translate(query)
+        )
+      )
     } else {
       translate(query)
     }
-    val items = collDocuments.coFind(filter,
+    val items = collDocuments.coFind(
+      filter,
       limit = maxPageSize,
       sort = jsonObjectOf(INTERNAL_ID to 1),
       projection = jsonObjectOf(CHUNK_META to 1, INTERNAL_ID to 1)
@@ -181,23 +204,27 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
   }
 
   override suspend fun addTags(query: IndexQuery, tags: Collection<String>) {
-    collDocuments.updateManyAwait(translate(query), jsonObjectOf(
-      "\$addToSet" to jsonObjectOf(
-        "tags" to jsonObjectOf(
-          "\$each" to tags
+    collDocuments.updateManyAwait(
+      translate(query), jsonObjectOf(
+        "\$addToSet" to jsonObjectOf(
+          "tags" to jsonObjectOf(
+            "\$each" to tags
+          )
         )
       )
-    ))
+    )
   }
 
   override suspend fun removeTags(query: IndexQuery, tags: Collection<String>) {
-    collDocuments.updateManyAwait(translate(query), jsonObjectOf(
-      "\$pull" to jsonObjectOf(
-        "tags" to jsonObjectOf(
-          "\$in" to tags
+    collDocuments.updateManyAwait(
+      translate(query), jsonObjectOf(
+        "\$pull" to jsonObjectOf(
+          "tags" to jsonObjectOf(
+            "\$in" to tags
+          )
         )
       )
-    ))
+    )
   }
 
   override suspend fun setProperties(query: IndexQuery, properties: Map<String, Any>) {
@@ -210,64 +237,84 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
     removeProperties(query, properties.keys)
 
     // now insert them (again or for the first time)
-    collDocuments.updateManyAwait(translate(query), jsonObjectOf(
-      "\$push" to jsonObjectOf(
-        "props" to jsonObjectOf(
-          "\$each" to props
-        )
-      )
-    ))
-  }
-
-  override suspend fun removeProperties(query: IndexQuery, properties: Collection<String>) {
-    collDocuments.updateManyAwait(translate(query), jsonObjectOf(
-      "\$pull" to jsonObjectOf(
-        "props" to jsonObjectOf(
-          "key" to jsonObjectOf(
-            "\$in" to properties.toList()
+    collDocuments.updateManyAwait(
+      translate(query), jsonObjectOf(
+        "\$push" to jsonObjectOf(
+          "props" to jsonObjectOf(
+            "\$each" to props
           )
         )
       )
-    ))
+    )
+  }
+
+  override suspend fun removeProperties(query: IndexQuery, properties: Collection<String>) {
+    collDocuments.updateManyAwait(
+      translate(query), jsonObjectOf(
+        "\$pull" to jsonObjectOf(
+          "props" to jsonObjectOf(
+            "key" to jsonObjectOf(
+              "\$in" to properties.toList()
+            )
+          )
+        )
+      )
+    )
   }
 
   override suspend fun getPropertyValues(query: IndexQuery, propertyName: String): Flow<Any?> {
-    val result = collDocuments.aggregateAwait(listOf(
-      jsonObjectOf("\$match" to translate(query)),
-      jsonObjectOf("\$unwind" to jsonObjectOf(
-        "path" to "\$props"
-      )),
-      jsonObjectOf("\$match" to jsonObjectOf(
-        "props.key" to propertyName
-      )),
-      jsonObjectOf("\$group" to jsonObjectOf(
-        "_id" to null,
-        "values" to jsonObjectOf(
-          "\$addToSet" to "\$props.value"
-        )
-      )),
-      jsonObjectOf("\$unwind" to "\$values")
-    ))
+    val result = collDocuments.aggregateAwait(
+      listOf(
+        jsonObjectOf("\$match" to translate(query)),
+        jsonObjectOf(
+          "\$unwind" to jsonObjectOf(
+            "path" to "\$props"
+          )
+        ),
+        jsonObjectOf(
+          "\$match" to jsonObjectOf(
+            "props.key" to propertyName
+          )
+        ),
+        jsonObjectOf(
+          "\$group" to jsonObjectOf(
+            "_id" to null,
+            "values" to jsonObjectOf(
+              "\$addToSet" to "\$props.value"
+            )
+          )
+        ),
+        jsonObjectOf("\$unwind" to "\$values")
+      )
+    )
     return result.map { it.getValue("values") }
   }
 
   override suspend fun getAttributeValues(query: IndexQuery, attributeName: String): Flow<Any?> {
-    val result = collDocuments.aggregateAwait(listOf(
-      jsonObjectOf("\$match" to translate(query)),
-      jsonObjectOf("\$unwind" to jsonObjectOf(
-        "path" to "\$genAttrs"
-      )),
-      jsonObjectOf("\$match" to jsonObjectOf(
-        "genAttrs.key" to attributeName
-      )),
-      jsonObjectOf("\$group" to jsonObjectOf(
-        "_id" to null,
-        "values" to jsonObjectOf(
-          "\$addToSet" to "\$genAttrs.value"
-        )
-      )),
-      jsonObjectOf("\$unwind" to "\$values")
-    ))
+    val result = collDocuments.aggregateAwait(
+      listOf(
+        jsonObjectOf("\$match" to translate(query)),
+        jsonObjectOf(
+          "\$unwind" to jsonObjectOf(
+            "path" to "\$genAttrs"
+          )
+        ),
+        jsonObjectOf(
+          "\$match" to jsonObjectOf(
+            "genAttrs.key" to attributeName
+          )
+        ),
+        jsonObjectOf(
+          "\$group" to jsonObjectOf(
+            "_id" to null,
+            "values" to jsonObjectOf(
+              "\$addToSet" to "\$genAttrs.value"
+            )
+          )
+        ),
+        jsonObjectOf("\$unwind" to "\$values")
+      )
+    )
     return result.map { it.getValue("values") }
   }
 
@@ -280,11 +327,13 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
     val chunk = mutableListOf<String>()
 
     val doDelete = suspend {
-      collDocuments.deleteManyAwait(jsonObjectOf(
-        INTERNAL_ID to jsonObjectOf(
-          "\$in" to chunk
+      collDocuments.deleteManyAwait(
+        jsonObjectOf(
+          INTERNAL_ID to jsonObjectOf(
+            "\$in" to chunk
+          )
         )
-      ))
+      )
     }
 
     for (p in paths) {
@@ -316,4 +365,57 @@ class MongoDBIndex private constructor() : Index, AbstractIndex() {
     ).firstOrNull() != null
   }
 
+  override suspend fun setUpDatabaseIndexes(indexes: List<DatabaseIndex>) {
+
+    // Get the indexes that already exist so we can figure out which indexes we still need to create
+    // and which ones can be dropped.
+    val existingIndexes = mutableListOf<String>()
+    collDocuments.listIndexes(BsonDocument::class.java).collect { index ->
+      val name = try {
+        index.getString("name").value
+      } catch (e: BsonInvalidOperationException) {
+        return@collect
+      }
+      if (name.startsWith(IDX_PREFIX)) {
+        existingIndexes.add(name)
+      }
+    }
+
+    fun indexDbName(idx: DatabaseIndex) = "$IDX_PREFIX${idx.name}"
+
+    // create indexes
+    for (idx in indexes) {
+
+      // only add indexes that do not already exist
+      val dbName = indexDbName(idx)
+      if (existingIndexes.contains(dbName)) {
+        continue
+      }
+
+      // add indexes
+      val options = IndexOptions()
+        .name(dbName)
+        .background(true)
+      val key = when (idx) {
+        is DatabaseIndex.Array -> jsonObjectOf(idx.field to 1)
+        is DatabaseIndex.ElemMatchCompare -> continue // only needed for postgres - mongodb already covers these cases with ElemMatchExists
+        is DatabaseIndex.ElemMatchExists -> jsonObjectOf(*idx.matchedOn.map { "${idx.field}.$it" to 1 }.toTypedArray())
+        is DatabaseIndex.Eq -> jsonObjectOf(idx.field to 1)
+        is DatabaseIndex.Geo -> jsonObjectOf(idx.field to "2dsphere")
+        is DatabaseIndex.Range -> jsonObjectOf(idx.field to 1)
+        is DatabaseIndex.StartsWith -> jsonObjectOf(idx.field to 1)
+      }
+      log.info("Adding database index $dbName")
+      collDocuments.createIndex(JsonObjectBsonAdapter(key), options).collect { }
+    }
+
+    // remove indexes
+    for (idx in existingIndexes) {
+      if (indexes.none { indexDbName(it) == idx }) {
+        log.info("Dropping database index $idx")
+        collDocuments.dropIndex(idx).collect { }
+      }
+    }
+
+  }
 }

--- a/src/main/kotlin/io/georocket/index/postgresql/JsonbTools.kt
+++ b/src/main/kotlin/io/georocket/index/postgresql/JsonbTools.kt
@@ -1,0 +1,95 @@
+/**
+ * @author Tobias Dorra
+ * Utility functions for generating (postgres) SQL queries involving the jsonb type.
+ */
+package io.georocket.index.postgresql
+
+import io.georocket.query.Compare
+import io.georocket.query.QueryPart.ComparisonOperator.*
+
+
+private fun checkField(field: String) {
+  if (!field.matches("""[a-zA-Z0-9]+""".toRegex())) {
+    throw IllegalArgumentException("Illegal field name: `$field'")
+  }
+}
+
+private fun scalarToSafeJson(value: Any): String {
+  return when (value) {
+    is String -> {
+      // aggressively escape anything that is not alphanumeric
+      // to rule out the possibility for injections of any kind
+      val escaped = value.map { char ->
+        val c = char.toString()
+        if (c.matches("[a-zA-Z0-9]".toRegex())) {
+          c
+        } else {
+          val hex = String.format("%04X", char.code)
+          "\\u$hex"
+        }
+      }.joinToString("")
+      "\"$escaped\""
+    }
+    is Number -> {
+      value.toString()
+    }
+    is Boolean -> if (value) "true" else "false"
+    else -> throw IllegalArgumentException("must be a scalar value (Number, String or Boolean)")
+  }
+}
+
+fun fieldJsonValue(jsonField: String, field: String): String {
+  val parts = field.split(".")
+  checkField(jsonField)
+  for (p in parts) {
+    checkField(p)
+  }
+  val cf = parts.joinToString(separator = "'->'", prefix = "'", postfix = "'")
+  return "${jsonField}->${cf}"
+}
+
+fun fieldStringValue(jsonField: String, field: String): String {
+  val parts = field.split(".").toMutableList()
+  checkField(jsonField)
+  for (p in parts) {
+    checkField(p)
+  }
+  val stringField = parts.removeLastOrNull() ?: return "$jsonField #>> '{}'"
+  return if (parts.isNotEmpty()) {
+    val path = parts.joinToString(separator = "'->'", prefix = "'", postfix = "'")
+    "$jsonField->$path->>'$stringField'"
+  } else {
+    "$jsonField->>'$stringField'"
+  }
+}
+
+/**
+ * Builds a jsonpath for an array-of-objects to a field of the array element(s) that match the given conditions.
+ *
+ * Example:
+ * jsonPathToArrayElementField(listOf(Compare("key", "iata_code", ComparisonOperator::EQ)), "value")
+ * returns the jsonpath to the field "value" of the array element(s) with key="iata_code":
+ * 'strict $[*] ? (@.key == "iata_code") . value'
+ * In the following json value, this jsonpath would match the value "FRA":
+ * [
+ *  {"key": "scalerank", "value": 3},
+ *  {"key": "featureclass", "value": "Airport"},
+ *  {"key": "iata_code", "value": "FRA"}
+ * ]
+ */
+fun jsonPathToArrayElementField(elementConditions: List<Compare>, field: String): String {
+  val jsonpath = java.lang.StringBuilder()
+  jsonpath.append("strict $[*]")
+  for (cond in elementConditions) {
+    val cmp = when (cond.op) {
+      EQ -> "=="
+      GT -> ">"
+      GTE -> ">="
+      LT -> "<"
+      LTE -> "<="
+    }
+    jsonpath.append(" ? (@. ${scalarToSafeJson(cond.field)} $cmp ${scalarToSafeJson(cond.value)})")
+  }
+  jsonpath.append(". ${scalarToSafeJson(field)}")
+  return jsonpath.toString()
+}

--- a/src/main/kotlin/io/georocket/index/xml/GmlIdIndexerFactory.kt
+++ b/src/main/kotlin/io/georocket/index/xml/GmlIdIndexerFactory.kt
@@ -1,5 +1,6 @@
 package io.georocket.index.xml
 
+import io.georocket.index.DatabaseIndex
 import io.georocket.index.Indexer
 import io.georocket.index.IndexerFactory
 import io.georocket.query.Contains
@@ -16,6 +17,11 @@ import io.georocket.util.XMLStreamEvent
  * @author Michel Kraemer
  */
 class GmlIdIndexerFactory : IndexerFactory {
+
+  companion object {
+    val validFieldNames = setOf("gmlId", "gml:id", "id")
+  }
+
   override fun <T : StreamEvent> createIndexer(eventType: Class<T>): Indexer<T>? {
     if (eventType.isAssignableFrom(XMLStreamEvent::class.java)) {
       @Suppress("UNCHECKED_CAST")
@@ -31,7 +37,7 @@ class GmlIdIndexerFactory : IndexerFactory {
   private fun isGmlIdEQ(qp: StringQueryPart): Boolean {
     val key = qp.key
     val comp = qp.comparisonOperator
-    return comp === ComparisonOperator.EQ && ("gmlId" == key || "gml:id" == key)
+    return comp === ComparisonOperator.EQ && validFieldNames.contains(key)
   }
 
   override fun getQueryPriority(queryPart: QueryPart): MatchPriority {
@@ -57,4 +63,8 @@ class GmlIdIndexerFactory : IndexerFactory {
       null
     }
   }
+
+  override fun getDatabaseIndexes(indexedFields: List<String>): List<DatabaseIndex> = listOf(
+    DatabaseIndex.Array("gmlIds", "gml_ids_array")
+  )
 }

--- a/src/main/kotlin/io/georocket/index/xml/XalAddressIndexerFactory.kt
+++ b/src/main/kotlin/io/georocket/index/xml/XalAddressIndexerFactory.kt
@@ -1,14 +1,11 @@
 package io.georocket.index.xml
 
+import io.georocket.index.DatabaseIndex
 import io.georocket.index.Indexer
 import io.georocket.index.IndexerFactory
-import io.georocket.query.Compare
-import io.georocket.query.IndexQuery
-import io.georocket.query.Or
+import io.georocket.query.*
 import io.georocket.query.QueryCompiler.MatchPriority
-import io.georocket.query.QueryPart
 import io.georocket.query.QueryPart.ComparisonOperator.EQ
-import io.georocket.query.StringQueryPart
 import io.georocket.util.StreamEvent
 import io.georocket.util.XMLStreamEvent
 
@@ -49,5 +46,12 @@ class XalAddressIndexerFactory : IndexerFactory {
 
       else -> null
     }
+  }
+
+  override fun getDatabaseIndexes(indexedFields: List<String>): List<DatabaseIndex> {
+    return XalAddressIndexer.Companion.Keys.values()
+      .map { k ->
+        DatabaseIndex.Eq("address.${k.key}", "address_${k.key}_eq")
+      }
   }
 }

--- a/src/main/kotlin/io/georocket/query/IndexQuery.kt
+++ b/src/main/kotlin/io/georocket/query/IndexQuery.kt
@@ -8,14 +8,32 @@ object All : IndexQuery
 data class And(val operands: List<IndexQuery>) : IndexQuery {
   constructor(vararg operands: IndexQuery) : this(operands.toList())
 }
+
 data class Or(val operands: List<IndexQuery>) : IndexQuery {
   constructor(vararg operands: IndexQuery) : this(operands.toList())
 }
+
 data class Not(val operand: IndexQuery) : IndexQuery
 data class StartsWith(val field: String, val prefix: String) : IndexQuery
 data class Compare(val field: String, val value: Any, val op: QueryPart.ComparisonOperator) : IndexQuery
-data class ElemMatch(val arrayField: String, val operands: List<Compare>) : IndexQuery {
-  constructor(field: String, vararg operands: Compare) : this(field, operands.toList())
+data class ElemMatchExists(val arrayField: String, val matches: List<Pair<String, Any>>) : IndexQuery {
+  constructor(arrayField: String, vararg matches: Pair<String, Any>) : this(arrayField, matches.asList())
 }
+
+/**
+ * Looks up and compares (see [Compare]) a value in an array of nested objects.
+ */
+data class ElemMatchCompare(
+  val arrayField: String,
+  val match: List<Pair<String, Any>>,
+  val condition: Compare
+) : IndexQuery {
+  constructor(arrayField: String, match1: Pair<String, Any>, condition: Compare) :
+    this(arrayField, listOf(match1), condition)
+
+  constructor(arrayField: String, match1: Pair<String, Any>, match2: Pair<String, Any>, condition: Compare) :
+    this(arrayField, listOf(match1, match2), condition)
+}
+
 data class Contains(val arrayField: String, val value: Any) : IndexQuery
 data class GeoIntersects(val field: String, val geometry: JsonObject) : IndexQuery

--- a/src/main/kotlin/io/georocket/query/QueryCompiler.kt
+++ b/src/main/kotlin/io/georocket/query/QueryCompiler.kt
@@ -1,5 +1,7 @@
 package io.georocket.query
 
+import io.georocket.index.DatabaseIndex
+
 /**
  * Compiles search strings to MongoDB queries
  * @since 1.0.0
@@ -26,6 +28,11 @@ interface QueryCompiler {
      */
     ONLY
   }
+
+  /**
+   * Return a list of database indexes, that can be used to accelerate the index queries returned by [compileQuery].
+   */
+  fun getDatabaseIndexes(indexedFields: List<String>): List<DatabaseIndex> = emptyList()
 
   /**
    * Get the priority with which the MongoDB query returned by [compileQuery]

--- a/src/test/resources/io/georocket/query/fixtures/address.json
+++ b/src/test/resources/io/georocket/query/fixtures/address.json
@@ -1,27 +1,53 @@
 {
   "query": "Main",
-  "queryCompilers": ["io.georocket.index.xml.XalAddressIndexerFactory"],
+  "queryCompilers": [
+    "io.georocket.index.xml.XalAddressIndexerFactory"
+  ],
   "expected": {
-    "$or": [{
-      "$or": [{
-        "address.Country": "Main"
-      }, {
-        "address.Locality": "Main"
-      }, {
-        "address.Street": "Main"
-      }, {
-        "address.Number": "Main"
-      }]
-    }, {
-      "$or": [{
-        "tags": "Main"
-      }, {
-        "props.value": "Main"
-      }]
-    }]
+    "$or": [
+      {
+        "$or": [
+          {
+            "address.Country": "Main"
+          },
+          {
+            "address.Locality": "Main"
+          },
+          {
+            "address.Street": "Main"
+          },
+          {
+            "address.Number": "Main"
+          }
+        ]
+      },
+      {
+        "$or": [
+          {
+            "tags": "Main"
+          },
+          {
+            "props.value": "Main"
+          }
+        ]
+      }
+    ]
   },
   "expectedPg": {
-    "where": "((data->'address'->'Country' = $1 OR data->'address'->'Locality' = $2 OR data->'address'->'Street' = $3 OR data->'address'->'Number' = $4) OR (data->'tags' ? $5 OR data->'props' @> $6))",
-    "params": ["Main", "Main", "Main", "Main", "Main", [{"value": "Main"}]]
+    "where": "((data->'address'->'Country' = $1 OR data->'address'->'Locality' = $2 OR data->'address'->'Street' = $3 OR data->'address'->'Number' = $4) OR (data->'tags' @> $5 OR data->'props' @> $6))",
+    "params": [
+      "Main",
+      "Main",
+      "Main",
+      "Main",
+      [
+        "Main"
+      ],
+      [
+        {
+          "value": "Main"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/and.json
+++ b/src/test/resources/io/georocket/query/fixtures/and.json
@@ -1,22 +1,48 @@
 {
   "query": "AND(foo bar)",
   "expected": {
-    "$and": [{
-      "$or": [{
-        "tags": "foo"
-      }, {
-        "props.value": "foo"
-      }]
-    }, {
-      "$or": [{
-        "tags": "bar"
-      }, {
-        "props.value": "bar"
-      }]
-    }]
+    "$and": [
+      {
+        "$or": [
+          {
+            "tags": "foo"
+          },
+          {
+            "props.value": "foo"
+          }
+        ]
+      },
+      {
+        "$or": [
+          {
+            "tags": "bar"
+          },
+          {
+            "props.value": "bar"
+          }
+        ]
+      }
+    ]
   },
   "expectedPg": {
-    "where": "((data->'tags' ? $1 OR data->'props' @> $2) AND (data->'tags' ? $3 OR data->'props' @> $4))",
-    "params": ["foo", [{"value": "foo"}], "bar", [{"value": "bar"}]]
+    "where": "((data->'tags' @> $1 OR data->'props' @> $2) AND (data->'tags' @> $3 OR data->'props' @> $4))",
+    "params": [
+      [
+        "foo"
+      ],
+      [
+        {
+          "value": "foo"
+        }
+      ],
+      [
+        "bar"
+      ],
+      [
+        {
+          "value": "bar"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/bounding_box_or_string.json
+++ b/src/test/resources/io/georocket/query/fixtures/bounding_box_or_string.json
@@ -26,16 +26,43 @@
     }]
   },
   "expectedPg": {
-    "where": "(ST_Intersects(ST_GeomFromGeoJSON(data->'bbox'), ST_GeomFromGeoJSON($1::jsonb)) OR (data->'tags' ? $2 OR data->'props' @> $3))",
-    "params": [{
-      "type": "Polygon",
-      "coordinates": [[
-        [1.0, 2.0],
-        [3.0, 2.0],
-        [3.0, 4.0],
-        [1.0, 4.0],
-        [1.0, 2.0]
-      ]]
-    }, "foobar", [{"value": "foobar"}]]
+    "where": "(ST_Intersects(ST_GeomFromGeoJSON(data->'bbox'), ST_GeomFromGeoJSON($1::jsonb)) OR (data->'tags' @> $2 OR data->'props' @> $3))",
+    "params": [
+      {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              1.0,
+              2.0
+            ],
+            [
+              3.0,
+              2.0
+            ],
+            [
+              3.0,
+              4.0
+            ],
+            [
+              1.0,
+              4.0
+            ],
+            [
+              1.0,
+              2.0
+            ]
+          ]
+        ]
+      },
+      [
+        "foobar"
+      ],
+      [
+        {
+          "value": "foobar"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/complex.json
+++ b/src/test/resources/io/georocket/query/fixtures/complex.json
@@ -1,60 +1,152 @@
 {
   "query": "AND(foo bar OR(test1 test2)) hello NOT(world \"you\")",
   "expected": {
-    "$or": [{
-      "$and": [{
-        "$or": [{
-          "tags": "foo"
-        }, {
-          "props.value": "foo"
-        }]
-      }, {
-        "$or": [{
-          "tags": "bar"
-        }, {
-          "props.value": "bar"
-        }]
-      }, {
-        "$or": [{
-          "$or": [{
-            "tags": "test1"
-          }, {
-            "props.value": "test1"
-          }]
-        }, {
-          "$or": [{
-            "tags": "test2"
-          }, {
-            "props.value": "test2"
-          }]
-        }]
-      }]
-    }, {
-      "$or": [{
-        "tags": "hello"
-      }, {
-        "props.value": "hello"
-      }]
-    }, {
-      "$not": {
-        "$or": [{
-          "$or": [{
-            "tags": "world"
-          }, {
-            "props.value": "world"
-          }]
-        }, {
-          "$or": [{
-            "tags": "you"
-          }, {
-            "props.value": "you"
-          }]
-        }]
+    "$or": [
+      {
+        "$and": [
+          {
+            "$or": [
+              {
+                "tags": "foo"
+              },
+              {
+                "props.value": "foo"
+              }
+            ]
+          },
+          {
+            "$or": [
+              {
+                "tags": "bar"
+              },
+              {
+                "props.value": "bar"
+              }
+            ]
+          },
+          {
+            "$or": [
+              {
+                "$or": [
+                  {
+                    "tags": "test1"
+                  },
+                  {
+                    "props.value": "test1"
+                  }
+                ]
+              },
+              {
+                "$or": [
+                  {
+                    "tags": "test2"
+                  },
+                  {
+                    "props.value": "test2"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "$or": [
+          {
+            "tags": "hello"
+          },
+          {
+            "props.value": "hello"
+          }
+        ]
+      },
+      {
+        "$not": {
+          "$or": [
+            {
+              "$or": [
+                {
+                  "tags": "world"
+                },
+                {
+                  "props.value": "world"
+                }
+              ]
+            },
+            {
+              "$or": [
+                {
+                  "tags": "you"
+                },
+                {
+                  "props.value": "you"
+                }
+              ]
+            }
+          ]
+        }
       }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "(((data->'tags' ? $1 OR data->'props' @> $2) AND (data->'tags' ? $3 OR data->'props' @> $4) AND ((data->'tags' ? $5 OR data->'props' @> $6) OR (data->'tags' ? $7 OR data->'props' @> $8))) OR (data->'tags' ? $9 OR data->'props' @> $10) OR NOT ((data->'tags' ? $11 OR data->'props' @> $12) OR (data->'tags' ? $13 OR data->'props' @> $14)))",
-    "params": ["foo", [{"value": "foo"}], "bar", [{"value": "bar"}], "test1", [{"value": "test1"}], "test2", [{"value": "test2"}], "hello", [{"value": "hello"}], "world", [{"value": "world"}], "you", [{"value": "you"}]]
+    "where": "(((data->'tags' @> $1 OR data->'props' @> $2) AND (data->'tags' @> $3 OR data->'props' @> $4) AND ((data->'tags' @> $5 OR data->'props' @> $6) OR (data->'tags' @> $7 OR data->'props' @> $8))) OR (data->'tags' @> $9 OR data->'props' @> $10) OR NOT ((data->'tags' @> $11 OR data->'props' @> $12) OR (data->'tags' @> $13 OR data->'props' @> $14)))",
+    "params": [
+      [
+        "foo"
+      ],
+      [
+        {
+          "value": "foo"
+        }
+      ],
+      [
+        "bar"
+      ],
+      [
+        {
+          "value": "bar"
+        }
+      ],
+      [
+        "test1"
+      ],
+      [
+        {
+          "value": "test1"
+        }
+      ],
+      [
+        "test2"
+      ],
+      [
+        {
+          "value": "test2"
+        }
+      ],
+      [
+        "hello"
+      ],
+      [
+        {
+          "value": "hello"
+        }
+      ],
+      [
+        "world"
+      ],
+      [
+        {
+          "value": "world"
+        }
+      ],
+      [
+        "you"
+      ],
+      [
+        {
+          "value": "you"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/gt.json
+++ b/src/test/resources/io/georocket/query/fixtures/gt.json
@@ -1,29 +1,37 @@
 {
   "query": "GT(foo 12)",
-  "queryCompilers": ["io.georocket.index.generic.GenericAttributeIndexerFactory"],
+  "queryCompilers": [
+    "io.georocket.index.generic.GenericAttributeIndexerFactory"
+  ],
   "expected": {
-    "$or": [{
-      "genAttrs": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$gt": 12
+    "$or": [
+      {
+        "genAttrs": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$gt": 12
+            }
+          }
+        }
+      },
+      {
+        "props": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$gt": 12
+            }
           }
         }
       }
-    }, {
-      "props": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$gt": 12
-          }
-        }
-      }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "(EXISTS (SELECT FROM jsonb_array_elements(data->'genAttrs') a WHERE a->'key' = $1 AND a->'value' > $2) OR EXISTS (SELECT FROM jsonb_array_elements(data->'props') a WHERE a->'key' = $3 AND a->'value' > $4))",
-    "params": ["foo", 12, "foo", 12]
+    "where": "(jsonb_path_query_first(data->'genAttrs', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')>$1 OR jsonb_path_query_first(data->'props', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')>$2)",
+    "params": [
+      12,
+      12
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/gt_string.json
+++ b/src/test/resources/io/georocket/query/fixtures/gt_string.json
@@ -1,29 +1,37 @@
 {
   "query": "GT(foo \"12\")",
-  "queryCompilers": ["io.georocket.index.generic.GenericAttributeIndexerFactory"],
+  "queryCompilers": [
+    "io.georocket.index.generic.GenericAttributeIndexerFactory"
+  ],
   "expected": {
-    "$or": [{
-      "genAttrs": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$gt": "12"
+    "$or": [
+      {
+        "genAttrs": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$gt": "12"
+            }
+          }
+        }
+      },
+      {
+        "props": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$gt": "12"
+            }
           }
         }
       }
-    }, {
-      "props": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$gt": "12"
-          }
-        }
-      }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "(EXISTS (SELECT FROM jsonb_array_elements(data->'genAttrs') a WHERE a->'key' = $1 AND a->'value' > $2) OR EXISTS (SELECT FROM jsonb_array_elements(data->'props') a WHERE a->'key' = $3 AND a->'value' > $4))",
-    "params": ["foo", "12", "foo", "12"]
+    "where": "(jsonb_path_query_first(data->'genAttrs', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')>$1 OR jsonb_path_query_first(data->'props', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')>$2)",
+    "params": [
+      "12",
+      "12"
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/gte.json
+++ b/src/test/resources/io/georocket/query/fixtures/gte.json
@@ -1,29 +1,37 @@
 {
   "query": "GTE(foo 12)",
-  "queryCompilers": ["io.georocket.index.generic.GenericAttributeIndexerFactory"],
+  "queryCompilers": [
+    "io.georocket.index.generic.GenericAttributeIndexerFactory"
+  ],
   "expected": {
-    "$or": [{
-      "genAttrs": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$gte": 12
+    "$or": [
+      {
+        "genAttrs": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$gte": 12
+            }
+          }
+        }
+      },
+      {
+        "props": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$gte": 12
+            }
           }
         }
       }
-    }, {
-      "props": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$gte": 12
-          }
-        }
-      }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "(EXISTS (SELECT FROM jsonb_array_elements(data->'genAttrs') a WHERE a->'key' = $1 AND a->'value' >= $2) OR EXISTS (SELECT FROM jsonb_array_elements(data->'props') a WHERE a->'key' = $3 AND a->'value' >= $4))",
-    "params": ["foo", 12, "foo", 12]
+    "where": "(jsonb_path_query_first(data->'genAttrs', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')>=$1 OR jsonb_path_query_first(data->'props', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')>=$2)",
+    "params": [
+      12,
+      12
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/implicit_or.json
+++ b/src/test/resources/io/georocket/query/fixtures/implicit_or.json
@@ -1,22 +1,48 @@
 {
   "query": "foo bar",
   "expected": {
-    "$or": [{
-      "$or": [{
-        "tags": "foo"
-      }, {
-        "props.value": "foo"
-      }]
-    }, {
-      "$or": [{
-        "tags": "bar"
-      }, {
-        "props.value": "bar"
-      }]
-    }]
+    "$or": [
+      {
+        "$or": [
+          {
+            "tags": "foo"
+          },
+          {
+            "props.value": "foo"
+          }
+        ]
+      },
+      {
+        "$or": [
+          {
+            "tags": "bar"
+          },
+          {
+            "props.value": "bar"
+          }
+        ]
+      }
+    ]
   },
   "expectedPg": {
-    "where": "((data->'tags' ? $1 OR data->'props' @> $2) OR (data->'tags' ? $3 OR data->'props' @> $4))",
-    "params": ["foo", [{"value": "foo"}], "bar", [{"value": "bar"}]]
+    "where": "((data->'tags' @> $1 OR data->'props' @> $2) OR (data->'tags' @> $3 OR data->'props' @> $4))",
+    "params": [
+      [
+        "foo"
+      ],
+      [
+        {
+          "value": "foo"
+        }
+      ],
+      [
+        "bar"
+      ],
+      [
+        {
+          "value": "bar"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/lt.json
+++ b/src/test/resources/io/georocket/query/fixtures/lt.json
@@ -1,29 +1,37 @@
 {
   "query": "LT(foo 12)",
-  "queryCompilers": ["io.georocket.index.generic.GenericAttributeIndexerFactory"],
+  "queryCompilers": [
+    "io.georocket.index.generic.GenericAttributeIndexerFactory"
+  ],
   "expected": {
-    "$or": [{
-      "genAttrs": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$lt": 12
+    "$or": [
+      {
+        "genAttrs": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$lt": 12
+            }
+          }
+        }
+      },
+      {
+        "props": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$lt": 12
+            }
           }
         }
       }
-    }, {
-      "props": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$lt": 12
-          }
-        }
-      }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "(EXISTS (SELECT FROM jsonb_array_elements(data->'genAttrs') a WHERE a->'key' = $1 AND a->'value' < $2) OR EXISTS (SELECT FROM jsonb_array_elements(data->'props') a WHERE a->'key' = $3 AND a->'value' < $4))",
-    "params": ["foo", 12, "foo", 12]
+    "where": "(jsonb_path_query_first(data->'genAttrs', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')<$1 OR jsonb_path_query_first(data->'props', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')<$2)",
+    "params": [
+      12,
+      12
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/lte.json
+++ b/src/test/resources/io/georocket/query/fixtures/lte.json
@@ -1,29 +1,37 @@
 {
   "query": "LTE(foo 12)",
-  "queryCompilers": ["io.georocket.index.generic.GenericAttributeIndexerFactory"],
+  "queryCompilers": [
+    "io.georocket.index.generic.GenericAttributeIndexerFactory"
+  ],
   "expected": {
-    "$or": [{
-      "genAttrs": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$lte": 12
+    "$or": [
+      {
+        "genAttrs": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$lte": 12
+            }
+          }
+        }
+      },
+      {
+        "props": {
+          "$elemMatch": {
+            "key": "foo",
+            "value": {
+              "$lte": 12
+            }
           }
         }
       }
-    }, {
-      "props": {
-        "$elemMatch": {
-          "key": "foo",
-          "value": {
-            "$lte": 12
-          }
-        }
-      }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "(EXISTS (SELECT FROM jsonb_array_elements(data->'genAttrs') a WHERE a->'key' = $1 AND a->'value' <= $2) OR EXISTS (SELECT FROM jsonb_array_elements(data->'props') a WHERE a->'key' = $3 AND a->'value' <= $4))",
-    "params": ["foo", 12, "foo", 12]
+    "where": "(jsonb_path_query_first(data->'genAttrs', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')<=$1 OR jsonb_path_query_first(data->'props', 'strict $[*] ? (@. \"key\" == \"foo\"). \"value\"')<=$2)",
+    "params": [
+      12,
+      12
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/not.json
+++ b/src/test/resources/io/georocket/query/fixtures/not.json
@@ -2,15 +2,27 @@
   "query": "NOT(foo)",
   "expected": {
     "$not": {
-      "$or": [{
-        "tags": "foo"
-      }, {
-        "props.value": "foo"
-      }]
+      "$or": [
+        {
+          "tags": "foo"
+        },
+        {
+          "props.value": "foo"
+        }
+      ]
     }
   },
   "expectedPg": {
-    "where": "NOT (data->'tags' ? $1 OR data->'props' @> $2)",
-    "params": ["foo", [{"value": "foo"}]]
+    "where": "NOT (data->'tags' @> $1 OR data->'props' @> $2)",
+    "params": [
+      [
+        "foo"
+      ],
+      [
+        {
+          "value": "foo"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/not_or.json
+++ b/src/test/resources/io/georocket/query/fixtures/not_or.json
@@ -2,23 +2,49 @@
   "query": "NOT(foo bar)",
   "expected": {
     "$not": {
-      "$or": [{
-        "$or": [{
-          "tags": "foo"
-        }, {
-          "props.value": "foo"
-        }]
-      }, {
-        "$or": [{
-          "tags": "bar"
-        }, {
-          "props.value": "bar"
-        }]
-      }]
+      "$or": [
+        {
+          "$or": [
+            {
+              "tags": "foo"
+            },
+            {
+              "props.value": "foo"
+            }
+          ]
+        },
+        {
+          "$or": [
+            {
+              "tags": "bar"
+            },
+            {
+              "props.value": "bar"
+            }
+          ]
+        }
+      ]
     }
   },
   "expectedPg": {
-    "where": "NOT ((data->'tags' ? $1 OR data->'props' @> $2) OR (data->'tags' ? $3 OR data->'props' @> $4))",
-    "params": ["foo", [{"value": "foo"}], "bar", [{"value": "bar"}]]
+    "where": "NOT ((data->'tags' @> $1 OR data->'props' @> $2) OR (data->'tags' @> $3 OR data->'props' @> $4))",
+    "params": [
+      [
+        "foo"
+      ],
+      [
+        {
+          "value": "foo"
+        }
+      ],
+      [
+        "bar"
+      ],
+      [
+        {
+          "value": "bar"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/string.json
+++ b/src/test/resources/io/georocket/query/fixtures/string.json
@@ -1,14 +1,26 @@
 {
   "query": "bla",
   "expected": {
-    "$or": [{
-      "tags": "bla"
-    }, {
-      "props.value": "bla"
-    }]
+    "$or": [
+      {
+        "tags": "bla"
+      },
+      {
+        "props.value": "bla"
+      }
+    ]
   },
   "expectedPg": {
-    "where": "(data->'tags' ? $1 OR data->'props' @> $2)",
-    "params": ["bla", [{"value": "bla"}]]
+    "where": "(data->'tags' @> $1 OR data->'props' @> $2)",
+    "params": [
+      [
+        "bla"
+      ],
+      [
+        {
+          "value": "bla"
+        }
+      ]
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/string_with_path.json
+++ b/src/test/resources/io/georocket/query/fixtures/string_with_path.json
@@ -2,20 +2,36 @@
   "query": "bla",
   "path": "mypath/",
   "expected": {
-    "$and": [{
-      "$or": [{
-        "tags": "bla"
-      }, {
-        "props.value": "bla"
-      }]
-    }, {
-      "layer": {
-        "$regex": "^mypath/"
+    "$and": [
+      {
+        "$or": [
+          {
+            "tags": "bla"
+          },
+          {
+            "props.value": "bla"
+          }
+        ]
+      },
+      {
+        "layer": {
+          "$regex": "^mypath/"
+        }
       }
-    }]
+    ]
   },
   "expectedPg": {
-    "where": "((data->'tags' ? $1 OR data->'props' @> $2) AND data->'layer'#>> '{}' LIKE $3)",
-    "params": ["bla", [{"value": "bla"}], "mypath/%"]
+    "where": "((data->'tags' @> $1 OR data->'props' @> $2) AND data->>'layer' LIKE $3)",
+    "params": [
+      [
+        "bla"
+      ],
+      [
+        {
+          "value": "bla"
+        }
+      ],
+      "mypath/%"
+    ]
   }
 }

--- a/src/test/resources/io/georocket/query/fixtures/string_with_root_path.json
+++ b/src/test/resources/io/georocket/query/fixtures/string_with_root_path.json
@@ -9,7 +9,16 @@
     }]
   },
   "expectedPg": {
-    "where": "(data->'tags' ? $1 OR data->'props' @> $2)",
-    "params": ["bla", [{"value": "bla"}]]
+    "where": "(data->'tags' @> $1 OR data->'props' @> $2)",
+    "params": [
+      [
+        "bla"
+      ],
+      [
+        {
+          "value": "bla"
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
A number of database indexes are created when the server is started.

Each IndexerFactory can implement the new method `getDatabaseIndexes` to declare which database indexes should be present to accelerate the queries that it generates. The actual creation of the database indexes is in the new method 'setUpDatabaseIndexes' in the PostgreSQLIndex / MongoDBIndex classes.

Georocket will manage all indexes that begin with the prefix `georocket_`. It will also drop indexes, that are not needed any more. The DBA can add their own indexes, but they should not begin with `georocket_` so that georocket won't drop them the next time it is restarted.

Postgres:
The query optimizer might still decide to use a sequential scan when it thinks that the query result covers a large percentage of the table. Postgres users might need to execute 'ANALYZE' after large data imports so that the query optimizer can use the collected statistics to guide this decision.
In order to support range queries for genAttrs/props (such as the query `LTE(scalerank 2)`), the corresponding fields have to be added to the new value `georocket.index.indexedFields` in the config file.
