### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -71,7 +71,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: georocket-docker-image
           path: /tmp
@@ -102,7 +102,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: georocket-docker-image
           path: /tmp

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,14 +39,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload Docker image as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: georocket-docker-image
           path: /tmp/georocket-docker-image.tar
           retention-days: 1
 
       - name: Upload junit test reports on failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: test-results

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation 'io.projectreactor:reactor-core:3.4.16'
 
     // embedded mongodb for standalone mode
-    implementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.3'
+    implementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.5'
 
     // PostgreSQL
     implementation "org.postgresql:postgresql:42.3.3"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ group = 'io.georocket'
 mainClassName = 'io.georocket.MainKt'
 
 ext {
-    vertxVersion = '4.2.5'
+    vertxVersion = '4.2.6'
     geotoolsVersion = '26.3'
     slf4jVersion = '1.7.36'
     logbackVersion = '1.2.11'

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.6.1'
 
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.32.0'
     testImplementation 'org.mongodb:mongodb-driver:3.12.10'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'com.h2database:h2:2.1.210'
     implementation 'com.vividsolutions:jts:1.13'
     implementation 'commons-io:commons-io:2.11.0'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2"
     implementation 'io.pebbletemplates:pebble:3.1.5'
     implementation 'javax.servlet:javax.servlet-api:4.0.1'
     implementation 'net.java.dev.jna:jna:5.11.0'
@@ -80,7 +80,7 @@ dependencies {
     implementation 'org.jline:jline:3.21.0'
     implementation 'org.yaml:snakeyaml:1.30'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.2'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2"
 
     implementation("org.geotools:gt-epsg-extension:$geotoolsVersion") {
         // exclude invalid dependency

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.6.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.jetbrains.kotlin.jvm from 1.6.10 to 1.6.21 (#325) @dependabot
* Bump actions/download-artifact from 2 to 3 (#324) @dependabot
* Bump actions/upload-artifact from 2 to 3 (#323) @dependabot
* Bump kotlinx-coroutines-reactive from 1.6.0 to 1.6.1 (#322) @dependabot
* Bump de.flapdoodle.embed.mongo from 3.4.3 to 3.4.5 (#320) @dependabot
* Bump jackson-module-kotlin from 2.13.1 to 2.13.2 (#319) @dependabot
* Bump vertxVersion from 4.2.5 to 4.2.6 (#317) @dependabot
